### PR TITLE
imgProc/sizeDist bug fixes and additions -- Addition of new example wrappers

### DIFF
--- a/BatchScript_Example_SLURM
+++ b/BatchScript_Example_SLURM
@@ -1,0 +1,28 @@
+#!/bin/sh
+#SBATCH --job-name=uiops_PECAN_20150706
+#SBATCH --output=uiops_PECAN_20150706.o%j
+#SBATCH --mail-type=ALL
+#SBATCH --mail-user=stechma2@illinois.edu
+#SBATCH -p d,g,e,f
+#SBATCH -N 1
+#SBATCH -n 12
+#SBATCH --mem-per-cpu=16000
+#SBATCH --time=24:00:00
+
+export OMP_NUM_THREADS=12
+cd /data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease
+
+
+#usage: automaticPECANprocessing_CL.py [-h] [-C] [-P] [-D] [-I] [-S] ddate
+#
+#positional arguments:
+#  ddate             date of the flight to be processed in YYYYMMDD
+#
+#optional arguments:
+#  -h, --help        show this help message and exit
+#  -C, --runCIP      process CIP data
+#  -P, --runPIP      process PIP data
+#  -D, --decompress  run raw image file decompression
+#  -I, --imgProc     run particle-by-particle processing
+#  -S, --sizeDist    run size distribution processing
+stdbuf -oL python automaticPECANprocessing_CL.py 20150706 -C -P -I

--- a/automaticDataProcessing_CL.py
+++ b/automaticDataProcessing_CL.py
@@ -28,9 +28,9 @@ imgProc     = args.imgProc
 sizeDist    = args.sizeDist
 
 
-inOutDir = '/data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease/'
+inOutDir = '/data/pecan/a/stechma2/pecan/mp-data/UIOPS/'
 
-os.chdir('/data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease')
+os.chdir('/data/pecan/a/stechma2/pecan/mp-data/UIOPS')
 
 os.system('source ~/.bashrc')
 
@@ -39,13 +39,13 @@ print('Starting UIOPS processing for PECAN ' + ddate)
 if decompress:
     if runCIP:
         print('Starting decompression of raw CIP image data... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
-        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runalldecompCIP(' + ddate  + ')"')
+        os.system('/sw/matlab-r2015a/bin/matlab -nodisplay -r "runalldecompCIP(' + ddate  + ')"')
         print('CIP Image decompression complete. Starting netCDF concatenation... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
         os.system('ncrcat -O ' + inOutDir + 'DIMG.CIP.' + ddate + '* ' +'DIMG.CIP.' + ddate + '.cdf')
     
     if runPIP:
         print('Starting decompression of raw PIP image data... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
-        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runalldecompPIP(' + ddate  + ')"')
+        os.system('/sw/matlab-r2015a/bin/matlab -nodisplay -r "runalldecompPIP(' + ddate  + ')"')
         print('PIP Image decompression complete. Starting netCDF concatenation... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
         os.system('ncrcat -O ' + inOutDir + 'DIMG.PIP.' + ddate + '* ' +'DIMG.PIP.' + ddate + '.cdf')
 

--- a/automaticDataProcessing_CL.py
+++ b/automaticDataProcessing_CL.py
@@ -1,0 +1,82 @@
+import os, subprocess
+import sys
+from datetime import datetime as dt
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("ddate", help="date of the flight to be processed in YYYYMMDD")
+parser.add_argument("-C", "--runCIP", help="process CIP data", action="store_true")
+parser.add_argument("-P", "--runPIP", help="process PIP data", action="store_true")
+parser.add_argument("-D", "--decompress", help="run raw image file decompression", action="store_true")
+parser.add_argument("-I", "--imgProc", help="run particle-by-particle processing", action="store_true")
+parser.add_argument("-S", "--sizeDist", help="run size distribution processing", action="store_true")
+
+args = parser.parse_args()
+
+if not args.runCIP and not args.runPIP:
+    sys.exit('You must specify at least one probe to process (--runCIP and/or --runPIP)')
+if not args.decompress and not args.imgProc and not args.sizeDist:
+    sys.exit('You must specify at least one processing step (options include: --decompress, --imgProc, --sizeDist)')
+
+ddate = args.ddate
+
+runCIP      = args.runCIP
+runPIP      = args.runPIP
+
+decompress  = args.decompress
+imgProc     = args.imgProc
+sizeDist    = args.sizeDist
+
+
+inOutDir = '/data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease/'
+
+os.chdir('/data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease')
+
+os.system('source ~/.bashrc')
+
+print('Starting UIOPS processing for PECAN ' + ddate)
+
+if decompress:
+    if runCIP:
+        print('Starting decompression of raw CIP image data... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runalldecompCIP(' + ddate  + ')"')
+        print('CIP Image decompression complete. Starting netCDF concatenation... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('ncrcat -O ' + inOutDir + 'DIMG.CIP.' + ddate + '* ' +'DIMG.CIP.' + ddate + '.cdf')
+    
+    if runPIP:
+        print('Starting decompression of raw PIP image data... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runalldecompPIP(' + ddate  + ')"')
+        print('PIP Image decompression complete. Starting netCDF concatenation... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('ncrcat -O ' + inOutDir + 'DIMG.PIP.' + ddate + '* ' +'DIMG.PIP.' + ddate + '.cdf')
+
+if imgProc:
+    if runCIP:
+        print('Starting CIP particle-by-particle image processing... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        timeline=subprocess.Popen('ncdump -h DIMG.CIP.' + ddate + '.cdf | grep UNLIMITED', shell=True, stdout=subprocess.PIPE)
+        nframes = timeline.stdout.read().split('(')[1].split()[0]
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runImgProc_sm_PECAN(' + nframes + ',' + ddate + ',' + '\'CIP\'' + ')"')
+        print('CIP particle-by-particle image processing complete. Starting netCDF concatenation... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('ncrcat ' + inOutDir + 'proc2.' + ddate + '.*.CIP.cdf ' +'proc2.' + ddate + '.CIP.cdf')
+
+    if runPIP:
+        print('Starting PIP particle-by-particle image processing... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        timeline=subprocess.Popen('ncdump -h DIMG.PIP.' + ddate + '.cdf | grep UNLIMITED', shell=True, stdout=subprocess.PIPE)
+        nframes = timeline.stdout.read().split('(')[1].split()[0]
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runImgProc_sm_PECAN(' + nframes + ',' + ddate + ',' + '\'PIP\'' + ')"')
+        print('PIP particle-by-particle image processing complete. Starting netCDF concatenation... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('ncrcat ' + inOutDir + 'proc2.' + ddate + '.*.PIP.cdf ' +'proc2.' + ddate + '.PIP.cdf')
+
+if sizeDist:
+    if runCIP and runPIP:
+        print('Starting CIP and PIP size distribution processing... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runSizeDistPECAN(' + ddate + ',' + repr(1) + ',' + repr(1) +')"')
+        print('CIP and PIP size distribution processing complete... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+    elif runCIP and not runPIP:
+        print('Starting CIP size distribution processing... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runSizeDistPECAN(' + ddate + ',' + repr(1) + ',' + repr(0) +')"')
+        print('CIP size distribution processing complete... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+    elif runPIP and not runCIP:
+        print('Starting PIP size distribution processing... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+        os.system('/sw/matlab-r2016b/bin/matlab -nodisplay -r "runSizeDistPECAN(' + ddate + ',' + repr(0) + ',' + repr(1) +')"')
+        print('PIP size distribution processing complete... ' + dt.strftime(dt.now(),'%H:%M:%S %Y%m%d'))
+    

--- a/imgProc_sm.m
+++ b/imgProc_sm.m
@@ -206,7 +206,7 @@ function imgProc_sm(infile, outfile, probename, n, nEvery, projectname, varargin
 	netcdf.putAtt(f, varid101, 'Description', 'Time since probe was activated')
 	
 	if probetype~=0 % Added by Joe Finlon - 06/22/17
-		varid102  = netcdf.defVar(f,'SliceCount','short',dimid0); %**TYPE?**
+		varid102  = netcdf.defVar(f,'SliceCount','short',dimid0);
 		netcdf.putAtt(f, varid102, 'Units', '--')
 		netcdf.putAtt(f, varid102, 'Description', 'Number of slices containing particle')
 		
@@ -214,7 +214,7 @@ function imgProc_sm(infile, outfile, probename, n, nEvery, projectname, varargin
 		netcdf.putAtt(f, varid103, 'Units', '--')
 		netcdf.putAtt(f, varid103, 'Description', 'Flag denoting out-of-focus (DMT) or overloaded (SPEC) particles')
 		
-		varid104  = netcdf.defVar(f,'Particle_number_all','int',dimid0); %**TYPE?** Will we ever exceed ~2 billion particles?
+		varid104  = netcdf.defVar(f,'Particle_number_all','int',dimid0);
 		netcdf.putAtt(f, varid104, 'Units', '--')
 		netcdf.putAtt(f, varid104, 'Description', 'Index of particle in 2-D buffer')
 	end

--- a/imgProc_sm.m
+++ b/imgProc_sm.m
@@ -1,16 +1,16 @@
 function imgProc_sm(infile, outfile, probename, n, nEvery, projectname, varargin)
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    
-%  This function is the image processing part of OAP processing using 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%  This function is the image processing part of OAP processing using
 %  distributed memory parallisation. The function use one simple interface
-%  for all probes. 
+%  for all probes.
 %
 %  Interface:
 %    infile   :   The input file name
 %    outfile  :   The output file name
 %    probetype:   One of the following: '2DC','2DP','CIP','PIP','HVPS' and '2DS'
-%    n        :   The nth chuck to be processed.  
+%    n        :   The nth chuck to be processed.
 %    nEvery   :   The individual chuck size. nChuck*nEvery shoudl equal the
-%                 total frame number 
+%                 total frame number
 %    projectname: The name of project so that you can write the specific
 %                 code for you data
 %    varargin :   OPTIONAL argument for the aircraft TAS file name
@@ -22,11 +22,11 @@ function imgProc_sm(infile, outfile, probename, n, nEvery, projectname, varargin
 %          various varibles
 %
 %  Update Dates:
-%    * Initially Written by Will Wu, 06/24/2013 
+%    * Initially Written by Will Wu, 06/24/2013
 %          imgprocdm(File,probetype,n)
-%    * Updated by Will Wu, 10/11/2013   
-%          New function interface 
-%          imgprocdm(infile,outfile,probetype,n, nEvery) and updated documentation. 
+%    * Updated by Will Wu, 10/11/2013
+%          New function interface
+%          imgprocdm(infile,outfile,probetype,n, nEvery) and updated documentation.
 %          This version is a major update to include all probes and simplify
 %          the function interface significantly
 %    * Updated by Will Wu, 07/10/2013
@@ -35,9 +35,9 @@ function imgProc_sm(infile, outfile, probename, n, nEvery, projectname, varargin
 %          length/width/angle
 %    * Added by Wei Wu, May 11, 2016
 %          Add the project specific code with projectname in the following format:
-%            if strcmp(projectname, 'PECAN')  % For example for PECAN dataset 
+%            if strcmp(projectname, 'PECAN')  % For example for PECAN dataset
 %               ...
-%            end 
+%            end
 %    * Updated by Will Wu, 07/11/2016
 %          New function name with the option to turn CGAL on and off for
 %          speed
@@ -55,767 +55,805 @@ function imgProc_sm(infile, outfile, probename, n, nEvery, projectname, varargin
 %          Omit saving DOF/Overload flag for 2DC/2DP since there is no
 %          equivalent for these probes.
 %          Added metadata for netCDF output.
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    
+%    * Updated by Dan Stechman, 08/01/2017
+%          Added PECAN-specific PIP time offset correction.
+%		   Added [potentially] PECAN-specific CIP/PIP corrupt record identification,
+%		   removal, and logging. 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Setting probe information according to probe type
 %    use ProbeType to indicate three type of probes:
-%       0: 2DC/2DP, 32 doides, boundary 85, 
+%       0: 2DC/2DP, 32 doides, boundary 85,
 %       1: CIP/PIP, 64 doides, boundary 170
 %       2: HVPS/2DS, 128 doides, boundary 170
- 
-
-iRectEllipse = 0;  % Set defualt to no Rectangle fit and Ellipse fit
-
-% Option to save diode stats for every particle
-% More than doubles filesize, and increase computation time
-% Only enable if actually needed
-calcAllDiodeStats = 0;
-
-switch probename
-    case '2DC'
-        boundary=[255 255 255 255];
-        boundarytime=85;
-
-        ds = 0.025;			     % Size of diode in millimeters
-        handles.diodesize = ds;  
-        handles.diodenum  = 32;  % Diode number
-        handles.current_image = 1;
-        probetype=0;
-
-    case '2DP'
-        boundary=[255 255 255 255];
-        boundarytime=85;
-
-        ds = 0.200;			     % Size of diode in millimeters
-        handles.diodesize = ds;  
-        handles.diodenum  = 32;  % Diode number
-        handles.current_image = 1;
-        probetype=0;
-
-    case 'CIP'
-        boundary=[170, 170, 170, 170, 170, 170, 170, 170];
-        boundarytime=NaN;
-
-        ds = 0.025;			     % Size of diode in millimeters
-        handles.diodesize = ds;
-        handles.diodenum  = 64;  % Diode number
-        handles.current_image = 1;
-        probetype=1;
-
-    case 'PIP'
-        boundary=[170, 170, 170, 170, 170, 170, 170, 170];
-        boundarytime=NaN;
-
-        ds = 0.100;			     % Size of diode in millimeters
-        handles.diodesize = ds;
-        handles.diodenum  = 64;  % Diode number
-        handles.current_image = 1;
-        probetype=1;
-        
-    case 'HVPS'
-        boundary=[43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690];
-        boundarytime=0;
-
-        ds = 0.150;			     % Size of diode in millimeters
-        handles.diodesize = ds;
-        handles.diodenum  = 128; % Diode number
-        handles.current_image = 1;
-        probetype=2;
-        % TAS file info - Added by Joe Finlon - 03/03/17
-        tasFile = varargin{1};
-        tas = ncread(tasFile, 'TAS'); % aircraft TAS in m/s
-        tasTime = ncread(tasFile, 'Time'); % aircraft time in HHMMSS
-        disp(['Using TAS data from ', tasFile])
-
-    case '2DS'
-        boundary=[43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690];
-        boundarytime=0;
-
-        ds = 0.010;			     % Size of diode in millimeters
-        handles.diodesize = ds;
-        handles.diodenum  = 128; % Diode number
-        handles.current_image = 1;
-        probetype=2;
-        % TAS file info - Added by Joe Finlon - 03/03/17
-        tasFile = varargin{1};
-        tas = ncread(tasFile, 'TAS'); % aircraft TAS in m/s
-        tasTime = ncread(tasFile, 'Time'); % aircraft time in HHMMSS
-        disp(['Using TAS data from ', tasFile])
-end
-
-diodenum = handles.diodenum;
-byteperslice = diodenum/8;  
-handles.disagree = 0;
-
-%% Read the particle image files
-handles.f = netcdf.open(infile,'nowrite');
-[~, dimlen] = netcdf.inqDim(handles.f,2);
-[~, handles.img_count] = netcdf.inqDim(handles.f,0);
-size_mat = dimlen; 
-warning off all
-diode_stats = zeros(1,diodenum);
-
-%if strcmp(projectname, 'PECAN')  % For example for PECAN dataset 
-%    if strcmp(probename, 'PIP')
-%        TimeOffsetSec = -12*3600.0;
-%        TimeOffsetSec_pos = TimeOffsetSec * -1;
-%        temp_offsethhmmss = insec2hhmmss(TimeOffsetSec_pos);
-%        part_hour_offset = -1 * (floor(temp_offsethhmmss/10000));
-%        part_min_offset = -1 * (floor(mod(temp_offsethhmmss,10000)/100));
-%        part_sec_offset = -1 * (floor(mod(temp_offsethhmmss,100)));
-%    end
-%end
-
-%% Create output NETCDF file and variables
-f = netcdf.create(outfile, 'clobber');
-dimid0 = netcdf.defDim(f,'time',netcdf.getConstant('NC_UNLIMITED'));
-dimid1 = netcdf.defDim(f,'pos_count',2);
-dimid2 = netcdf.defDim(f,'bin_count',diodenum);
-
-NC_GLOBAL = netcdf.getConstant('NC_GLOBAL');
-netcdf.putAtt(f, NC_GLOBAL, 'Software', 'UIOPS/imgProc_sm');
-netcdf.putAtt(f, NC_GLOBAL, 'Institution', 'Univ. Illinois, Dept. Atmos. Sciences');
-netcdf.putAtt(f, NC_GLOBAL, 'Creation Time', datestr(now, 'yyyy/mm/dd HH:MM:SS'));
-netcdf.putAtt(f, NC_GLOBAL, 'Description', ['Contains size, morphological, ',...
-    'and other particle properties from an uncompressed image file.']);
-netcdf.putAtt(f, NC_GLOBAL, 'Project', projectname);
-netcdf.putAtt(f, NC_GLOBAL, 'Image Source', infile);
-netcdf.putAtt(f, NC_GLOBAL, 'Probe Type', probename);
-if iRectEllipse && calcAllDiodeStats
-    netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active',...
-        'Rectangle & elliptical fits & per-particle diode statistics');
-elseif iRectEllipse && ~calcAllDiodeStats
-    netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active',...
-        'Rectangle & elliptical fits');
-elseif ~iRectEllipse && calcAllDiodeStats
-    netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active',...
-        'Per-particle diode statistics');
-else
-    netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active', 'None')
-end
-
-
-varid1 = netcdf.defVar(f,'Date','double',dimid0);
-netcdf.putAtt(f, varid1, 'Units', 'YYYYMMDD')
-netcdf.putAtt(f, varid1, 'Description', 'Date of image record in which the particle resides')
-
-varid0  = netcdf.defVar(f,'Time','double',dimid0);
-netcdf.putAtt(f, varid0, 'Units', 'HHMMSS')
-netcdf.putAtt(f, varid0, 'Description', 'Time (UTC) of image record in which the particle resides')
-
-varid2  = netcdf.defVar(f,'msec','double',dimid0);
-netcdf.putAtt(f, varid2, 'Units', 'ms')
-netcdf.putAtt(f, varid2, 'Description', 'Sub-second time of image record in which the particle resides')
-
-varid101  = netcdf.defVar(f,'Time_in_seconds','double',dimid0);
-netcdf.putAtt(f, varid101, 'Units', 'sec')
-netcdf.putAtt(f, varid101, 'Description', 'Time since probe was activated')
-
-if probetype~=0 % Added by Joe Finlon - 06/22/17 
-    varid102  = netcdf.defVar(f,'SliceCount','double',dimid0);
-    netcdf.putAtt(f, varid102, 'Units', '--')
-    netcdf.putAtt(f, varid102, 'Description', 'Number of slices containing particle')
-    
-    varid103  = netcdf.defVar(f,'DMT_DOF_SPEC_OVERLOAD','double',dimid0);
-    netcdf.putAtt(f, varid103, 'Units', '--')
-    netcdf.putAtt(f, varid103, 'Description', 'Flag denoting out-of-focus (DMT) or overloaded (SPEC) particles')
-    
-    varid104  = netcdf.defVar(f,'Particle_number_all','double',dimid0);
-    netcdf.putAtt(f, varid104, 'Units', '--')
-    netcdf.putAtt(f, varid104, 'Description', 'Index of particle in 2-D buffer')
-end
-%varid3 = netcdf.defVar(f,'wkday','double',dimid0);
-varid4  = netcdf.defVar(f,'position','double',[dimid1 dimid0]);
-netcdf.putAtt(f, varid4, 'Units', '--')
-netcdf.putAtt(f, varid4, 'Description', 'Slice within image record where particle is first sampled')
-
-varid5  = netcdf.defVar(f,'particle_time','double',dimid0);
-netcdf.putAtt(f, varid5, 'Units', 'HHMMSS')
-netcdf.putAtt(f, varid5, 'Description', 'Particle time (not available for 2DS/HVPS)')
-
-varid6  = netcdf.defVar(f,'particle_millisec','double',dimid0);
-netcdf.putAtt(f, varid6, 'Units', 'ms')
-netcdf.putAtt(f, varid6, 'Description', 'Sub-second particle time (not available for 2DS/HVPS)')
-
-varid7  = netcdf.defVar(f,'particle_microsec','double',dimid0);
-netcdf.putAtt(f, varid7, 'Units', 'microsec')
-netcdf.putAtt(f, varid7, 'Description', 'Sub-second particle time (unitless clock count for 2DS/HVPS)')
-
-varid8  = netcdf.defVar(f,'parent_rec_num','double',dimid0);
-netcdf.putAtt(f, varid8, 'Units', '--')
-netcdf.putAtt(f, varid8, 'Description', 'Index of image record in which the particle resides')
-
-varid9  = netcdf.defVar(f,'particle_num','double',dimid0);
-netcdf.putAtt(f, varid9, 'Units', '--')
-netcdf.putAtt(f, varid9, 'Description', 'Particle index within current image record')
-
-varid10 = netcdf.defVar(f,'image_length','double',dimid0);
-netcdf.putAtt(f, varid10, 'Units', '--')
-netcdf.putAtt(f, varid10, 'Description', 'Particle length in time direction using # photodiodes')
-
-varid11 = netcdf.defVar(f,'image_width','double',dimid0);
-netcdf.putAtt(f, varid11, 'Units', '--')
-netcdf.putAtt(f, varid11, 'Description', 'Particle length in photodiode direction using # photodiodes')
-
-varid12 = netcdf.defVar(f,'image_area','double',dimid0);
-netcdf.putAtt(f, varid12, 'Units', 'mm^2')
-netcdf.putAtt(f, varid12, 'Description', 'Projected area using the # shadowed photodiodes')
-
-varid13 = netcdf.defVar(f,'image_longest_y','double',dimid0);
-netcdf.putAtt(f, varid13, 'Units', '--')
-netcdf.putAtt(f, varid13, 'Description', 'Longest vertically-oriented chord through particle in time direction')
-
-varid14 = netcdf.defVar(f,'image_max_top_edge_touching','double',dimid0);
-netcdf.putAtt(f, varid14, 'Units', '--')
-netcdf.putAtt(f, varid14, 'Description', 'Maximum # of times the bottom diode is shadowed in succession')
-
-varid15 = netcdf.defVar(f,'image_max_bottom_edge_touching','double',dimid0);
-netcdf.putAtt(f, varid15, 'Units', '--')
-netcdf.putAtt(f, varid15, 'Description', 'Maximum # of times the top diode is shadowed in succession')
-
-varid16 = netcdf.defVar(f,'image_touching_edge','double',dimid0);
-netcdf.putAtt(f, varid16, 'Units', '--')
-netcdf.putAtt(f, varid16, 'Description', '0 denotes image entirely in array; 1 denotes image touching edge')
-
-varid17 = netcdf.defVar(f,'image_auto_reject','double',dimid0);
-netcdf.putAtt(f, varid17, 'Units', '--')
-netcdf.putAtt(f, varid17, 'Description', ['ASCII reject code ("0" or 48: accepted; "a" or 97: aspect ratio > 6; ',...
-    '"t" or 116: aspect ratio > 5 + image touching edge; ',...
-    '"p" or 112: < 25% shadowed diodes in rectangle encompassing particle; ',...
-    '"h" or 104 or 72 or 117: hollow particle; "s" or 115: split image; ',...
-    '"z" or 122: zero area image; "f" or 102: zero area image)'])
-
-varid18 = netcdf.defVar(f,'image_hollow','double',dimid0);
-netcdf.putAtt(f, varid18, 'Units', '--')
-netcdf.putAtt(f, varid18, 'Description', '0 denotes not hollow; 1 denotes a hollow image')
-
-varid19 = netcdf.defVar(f,'image_center_in','double',dimid0);
-netcdf.putAtt(f, varid19, 'Units', '--')
-netcdf.putAtt(f, varid19, 'Description', '0 denotes center of particle outside array; 1 denotes center is inside')
-
-varid20 = netcdf.defVar(f,'image_axis_ratio','double',dimid0);
-netcdf.putAtt(f, varid20, 'Units', '--')
-netcdf.putAtt(f, varid20, 'Description', 'Ratio between maximum vertical length and maximum horizontal length')
-
-varid21 = netcdf.defVar(f,'image_diam_circle_fit','double',dimid0);
-netcdf.putAtt(f, varid21, 'Units', 'mm')
-netcdf.putAtt(f, varid21, 'Description', 'Dmax following Heymsfield & Parrish (1978)')
-
-varid22 = netcdf.defVar(f,'image_diam_horiz_chord','double',dimid0);
-netcdf.putAtt(f, varid22, 'Units', 'mm')
-netcdf.putAtt(f, varid22, 'Description', 'Dmax from # slices+1; best for sideways-looking probes')
-
-varid23 = netcdf.defVar(f,'image_diam_horiz_chord_corr','double',dimid0);
-netcdf.putAtt(f, varid23, 'Units', 'mm')
-netcdf.putAtt(f, varid23, 'Description', 'Dmax from # slices+1, with Korolev (2007) correction applied to hollow spherical particles')
-
-varid24 = netcdf.defVar(f,'image_diam_following_bamex_code','double',dimid0);
-netcdf.putAtt(f, varid24, 'Units', 'mm')
-netcdf.putAtt(f, varid24, 'Description', 'Dmax from maximum length chord through the particle')
-
-varid25 = netcdf.defVar(f,'image_diam_vert_chord','double',dimid0);
-netcdf.putAtt(f, varid25, 'Units', 'mm')
-netcdf.putAtt(f, varid25, 'Description', ['Dmax from maximum length in photodiode direction; ',...
-    'best for sideways-looking probes'])
-
-varid26 = netcdf.defVar(f,'image_diam_minR','double',dimid0);
-netcdf.putAtt(f, varid26, 'Units', 'mm')
-netcdf.putAtt(f, varid26, 'Description', 'Dmax of smallest circle enclosing the particle')
-
-varid27 = netcdf.defVar(f,'image_diam_AreaR','double',dimid0);
-netcdf.putAtt(f, varid27, 'Units', 'mm')
-netcdf.putAtt(f, varid27, 'Description', 'Area equivalent diameter')
-
-varid45 = netcdf.defVar(f,'image_perimeter','double',dimid0);
-netcdf.putAtt(f, varid45, 'Units', 'mm')
-netcdf.putAtt(f, varid45, 'Description', 'Perimeter following the particle boundary')
-
-if 1==iRectEllipse 
-    varid46 = netcdf.defVar(f,'image_RectangleL','double',dimid0);
-    netcdf.putAtt(f, varid46, 'Units', 'mm')
-    netcdf.putAtt(f, varid46, 'Description', 'Length of smallest rectangle enclosing the particle')
-
-    varid47 = netcdf.defVar(f,'image_RectangleW','double',dimid0);
-    netcdf.putAtt(f, varid47, 'Units', 'mm')
-    netcdf.putAtt(f, varid47, 'Description', 'Width of smallest rectangle enclosing the particle')
-    
-    varid67 = netcdf.defVar(f,'image_RectangleAngle','double',dimid0);
-    netcdf.putAtt(f, varid67, 'Units', 'radians')
-    netcdf.putAtt(f, varid67, 'Description', 'Angle of rectangle with respect to the time direction')
-    
-    varid48 = netcdf.defVar(f,'image_EllipseL','double',dimid0);
-    netcdf.putAtt(f, varid48, 'Units', 'mm')
-    netcdf.putAtt(f, varid48, 'Description', 'Length of smallest ellipse enclosing the particle')
-    
-    varid49 = netcdf.defVar(f,'image_EllipseW','double',dimid0);
-    netcdf.putAtt(f, varid49, 'Units', 'mm')
-    netcdf.putAtt(f, varid49, 'Description', 'Width of smallest ellipse enclosing the particle')
-    
-    varid69 = netcdf.defVar(f,'image_EllipseAngle','double',dimid0);
-    netcdf.putAtt(f, varid69, 'Units', 'radians')
-    netcdf.putAtt(f, varid69, 'Description', 'Angle of rectangle with respect to the time direction')
-end
-varid28 = netcdf.defVar(f,'percent_shadow_area','double',dimid0);
-netcdf.putAtt(f, varid28, 'Units', 'percent')
-netcdf.putAtt(f, varid28, 'Description', 'Ratio between the projected area and L*W')
-
-varid29 = netcdf.defVar(f,'edge_at_max_hole','double',dimid0);
-netcdf.putAtt(f, varid29, 'Units', '--')
-netcdf.putAtt(f, varid29, 'Description', ['# diodes between edges of the particle for the slice ',...
-    'containing the largest gap inside the particle'])
-
-varid30 = netcdf.defVar(f,'max_hole_diameter','double',dimid0);
-netcdf.putAtt(f, varid30, 'Units', '--')
-netcdf.putAtt(f, varid30, 'Description', 'Diameter of the largest hole inside the particle')
-
-varid31 = netcdf.defVar(f,'part_z','double',dimid0);
-netcdf.putAtt(f, varid31, 'Units', '--')
-netcdf.putAtt(f, varid31, 'Description', 'Particle depth in object plane calculated via lookup table')
-
-varid32 = netcdf.defVar(f,'size_factor','double',dimid0);
-netcdf.putAtt(f, varid32, 'Units', '--')
-netcdf.putAtt(f, varid32, 'Description', 'Dmax reduction factor folowing Korolev (2007) correction')
-
-varid33 = netcdf.defVar(f,'holroyd_habit','double',dimid0);
-netcdf.putAtt(f, varid33, 'Units', '--')
-netcdf.putAtt(f, varid33, 'Description', ['ASCII habit code following the Holroyd (1987) algorithm ',...
-    '("M" or 77: zero image; "C" or 67: center-out image; "t" or 116: tiny; "o" or 111: oriented; ',...
-    '"l" or 108: linear; "a" or 97: aggregate; "g" or 103: graupel; "s" or 115: sphere; ',...
-    '"h" or 104: hexagonal; "i" or 105: irregular; "d" or 100: dendrite)'])
-
-varid34 = netcdf.defVar(f,'area_hole_ratio','double',dimid0);
-netcdf.putAtt(f, varid34, 'Units', '--')
-netcdf.putAtt(f, varid34, 'Description', 'Ratio between the projected area and the area of hole inside particle')
-
-varid35 = netcdf.defVar(f,'inter_arrival','double',dimid0);
-netcdf.putAtt(f, varid35, 'Units', 'sec')
-netcdf.putAtt(f, varid35, 'Description', ['Inter-arrival time between particles ',...
-    '(use diff(time_in_seconds) for 2DS/HVPS)'])
-
-varid36 = netcdf.defVar(f,'bin_stats','double',dimid2);
-netcdf.putAtt(f, varid36, 'Units', '--')
-netcdf.putAtt(f, varid36, 'Description', '# times specified photodiode is shadowed for particles in this file')
-
-if calcAllDiodeStats
-    varid37 = netcdf.defVar(f,'image_bin_stats','double',[dimid2 dimid0]);
-    netcdf.putAtt(f, varid37, 'Units', '--')
-    netcdf.putAtt(f, varid37, 'Description', '# times specified photodiode is shadowed for each particle')
-end
-
-netcdf.endDef(f)
-
-%% Variables initialization 
-kk=1;
-w=-1;
-wstart = 0;
-firstTime = 1; % Used only for time offset correction (PECAN)
-
-time_offset_hr = 0;
-time_offset_mn = 0;
-time_offset_sec = 0;
-time_offset_ms = 0;
-timeset_flag = 0;
-
-
-
-%% Processing nth chuck. Every chuck is nEvery frame
-%% Analyze each individual particle images and Outpu the particle by particle information
-for i=((n-1)*nEvery+1):min(n*nEvery,handles.img_count)
-
-    handles.year     = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'year'    ),i-1,1);
-    handles.month    = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'month'  ),i-1,1);
-    handles.day      = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'day'  ),i-1,1);
-    handles.hour     = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'hour'    ),i-1,1);
-    handles.minute   = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'minute'  ),i-1,1);
-    handles.second   = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'second'  ),i-1,1);
-    handles.millisec = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'millisec'),i-1,1);
-  
-    if mod(i,100) == 0
-        disp([num2str(i),'/',num2str(handles.img_count), ', ',datestr(now)])
-    end
-    varid = netcdf.inqVarID(handles.f,'data');
-    
-    if probetype==0
-        temp = netcdf.getVar(handles.f,varid,[0, 0, i-1], [4,1024,1]);
-    else
-        temp = netcdf.getVar(handles.f,varid,[0, 0, i-1], [8,1700,1]);
-    end
-    data(:,:) = temp';  
-    
-    j=1;
-    start=0;
-    firstpart = 1;
-    
-    %c=[dec2bin(data(:,1),8),dec2bin(data(:,2),8),dec2bin(data(:,3),8),dec2bin(data(:,4),8)];
-    while data(j,1) ~= -1 && j < size(data,1)
-        % Calculate every particles
-        if (isequal(data(j,:), boundary) && ( (isequal(data(j+1,1), boundarytime) || probetype==1) ) )
-           if start ==0
-               if 1 == probetype 
-                   start = 2;
-               elseif 0 == probetype
-                   start = 2;
-               else
-                   start = 1;
-               end
-           end
-            
-               if probetype==0
-                   if start+1 > (j-1)  % Remove Corrupted Data
-                    break;
-                   end
-               else
-                   if start > (j-1)  % Remove Corrupted Data
-                    break;
-                   end
-               end 
-                
-                header_loc = j+1;
-                w=w+1;
-                %% Create binary image according to probe type
-                   
-                if probetype==0    
-                    ind_matrix(1:j-start-1,:) = data(start+1:j-1,:);  % 2DC has 3 slices between particles (sync word timing word and end of particle words)
-                    c=[dec2bin(ind_matrix(:,1),8),dec2bin(ind_matrix(:,2),8),dec2bin(ind_matrix(:,3),8),dec2bin(ind_matrix(:,4),8)];
-                elseif probetype==1
-                    ind_matrix(1:j-start,:) = data(start:j-1,:);
-                    c=[dec2bin(ind_matrix(:,1),8), dec2bin(ind_matrix(:,2),8),dec2bin(ind_matrix(:,3),8),dec2bin(ind_matrix(:,4),8), ...
-                    dec2bin(ind_matrix(:,5),8), dec2bin(ind_matrix(:,6),8),dec2bin(ind_matrix(:,7),8),dec2bin(ind_matrix(:,8),8)];
-                elseif probetype==2
-                    ind_matrix(1:j-start,:) = 65535 - data(start:j-1,:); % I used 1 to indicate the illuminated doides for HVPS
-                    c=[dec2bin(ind_matrix(:,1),16), dec2bin(ind_matrix(:,2),16),dec2bin(ind_matrix(:,3),16),dec2bin(ind_matrix(:,4),16), ...
-                    dec2bin(ind_matrix(:,5),16), dec2bin(ind_matrix(:,6),16),dec2bin(ind_matrix(:,7),16),dec2bin(ind_matrix(:,8),16)];
-                end
-                
-                % Just to test if there is bad images, usually 0 area images
-                figsize = size(c);
-                if figsize(2)~=diodenum
-                    disp('Not equal to doide number');
-                    return
-                end
-                
-                
-                images.position(kk,:) = [start, j-1];
-                parent_rec_num(kk)=i;
-                particle_num(kk) = mod(kk,66536); %hex2dec([dec2hex(data(start-1,7)),dec2hex(data(start-1,8))]);
-                
-                %  Get the particle time 
-                if probetype==0 
-                    bin_convert = [dec2bin(data(header_loc,2),8),dec2bin(data(header_loc,3),8),dec2bin(data(header_loc,4),8)];
-                    part_time = bin2dec(bin_convert);       % Interarrival time in tas clock cycles
-                    tas2d = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'tas'),i-1, 1);
-                    part_time = part_time/tas2d*handles.diodesize/(10^3);                    
-                    time_in_seconds(kk) = part_time;
-
-                    images.int_arrival(kk) = part_time;
-                    
-                    if(firstpart == 1)
-                        firstpart = 0;
-                        start_hour = handles.hour;
-                        start_minute = handles.minute;
-                        start_second = handles.second;
-                        start_msec = handles.millisec*10;
-                        % First, we get the hours....
-                        start_msec = start_msec;
-                        start_microsec = 0;
-                        time_offset_hr = 0;
-                        time_offset_mn = 0;
-                        time_offset_sec = 0;
-                        time_offset_ms = 0;
-
-                        part_hour(kk) = start_hour;
-                        part_min(kk) = start_minute;
-                        part_sec(kk) = start_second;
-                        part_mil(kk) = start_msec;
-                        part_micro(kk) = 0;
-                    else
-                        frac_time = part_time - floor(part_time);
-                        frac_time = frac_time * 1000;
-                        part_micro(kk) = part_micro(kk-1) + (frac_time - floor(frac_time))*1000;
-                        part_mil(kk) = part_mil(kk-1) + floor(frac_time);
-                        part_sec(kk) = part_sec(kk-1) + floor(part_time);
-                        part_min(kk) = part_min(kk-1);
-                        part_hour(kk) = part_hour(kk-1);
-                    end
-                    
-                    part_sec(part_mil >= 1000) = part_sec(part_mil >= 1000) + 1;
-                    part_mil(part_mil >= 1000) = part_mil(part_mil >= 1000) - 1000;
-
-                    part_min(part_sec >= 60) = part_min(part_sec >= 60) + 1;
-                    part_sec(part_sec >= 60) = part_sec(part_sec >= 60) - 60;
-
-                    part_hour(part_min >= 60) = part_hour(part_min >= 60) + 1;
-                    part_min(part_min >= 60) = part_min(part_min >= 60) - 60;
-                    part_hour(part_hour >= 24) = part_hour(part_hour >= 24) - 24;
-                elseif probetype==1
-                    bin_convert = [dec2bin(data(start-1,2),8),dec2bin(data(start-1,3),8),dec2bin(data(start-1,4),8), ...
-                        dec2bin(data(start-1,5),8), dec2bin(data(start-1,6),8)];
-
-                    part_hour(kk) = bin2dec(bin_convert(1:5));
-                    part_min(kk) = bin2dec(bin_convert(6:11));
-                    part_sec(kk) = bin2dec(bin_convert(12:17));
-                    part_mil(kk) = bin2dec(bin_convert(18:27));
-                    part_micro(kk) = bin2dec(bin_convert(28:40))*125e-9;
-                
-                    particle_sliceCount(kk)=bitand(data(start-1,1),127);
-                    particle_DOF(kk)=bitand(data(start-1,1),128);
-                    particle_partNum(kk)=bin2dec([dec2bin(data(start-1,7),8),dec2bin(data(start-1,8),8)]);
-
-                    time_in_seconds(kk) = part_hour(kk) * 3600 + part_min(kk) * 60 + part_sec(kk) + part_mil(kk)/1000 + part_micro(kk);
-                    
-                    % Deprecated - can be used to apply project/date specific time offset corrections
-                    %{
-                    if (exist('TimeOffsetSec') && TimeOffsetSec ~= 0 && (handles.month ~= 7 && handles.day ~= 1))
-                    	if (firstTime == 1 && kk == 1)
-                    		fprintf('Time correction applied to %s: %d seconds\n',probename,TimeOffsetSec);
-                    	end
-						%fprintf('Time in seconds before correction: %d\n',time_in_seconds(kk));
-						%fprintf('Particle hour before correction: %d\n',part_hour(kk));
-						%fprintf('Particle minute before correction: %d\n',part_min(kk));
-						%fprintf('Particle sec before correction: %d\n',part_sec(kk));
+	
+	
+	iRectEllipse = 0;  % Set defualt to no Rectangle fit and Ellipse fit
+	
+	% Option to save diode stats for every particle
+	% More than doubles filesize, and increase computation time
+	% Only enable if actually needed
+	calcAllDiodeStats = 0;
+	
+	switch probename
+		case '2DC'
+			boundary=[255 255 255 255];
+			boundarytime=85;
+			
+			ds = 0.025;			     % Size of diode in millimeters
+			handles.diodesize = ds;
+			handles.diodenum  = 32;  % Diode number
+			handles.current_image = 1;
+			probetype=0;
+			
+		case '2DP'
+			boundary=[255 255 255 255];
+			boundarytime=85;
+			
+			ds = 0.200;			     % Size of diode in millimeters
+			handles.diodesize = ds;
+			handles.diodenum  = 32;  % Diode number
+			handles.current_image = 1;
+			probetype=0;
+			
+		case 'CIP'
+			boundary=[170, 170, 170, 170, 170, 170, 170, 170];
+			boundarytime=NaN;
+			
+			ds = 0.025;			     % Size of diode in millimeters
+			handles.diodesize = ds;
+			handles.diodenum  = 64;  % Diode number
+			handles.current_image = 1;
+			probetype=1;
+			
+		case 'PIP'
+			boundary=[170, 170, 170, 170, 170, 170, 170, 170];
+			boundarytime=NaN;
+			
+			ds = 0.100;			     % Size of diode in millimeters
+			handles.diodesize = ds;
+			handles.diodenum  = 64;  % Diode number
+			handles.current_image = 1;
+			probetype=1;
+			
+		case 'HVPS'
+			boundary=[43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690];
+			boundarytime=0;
+			
+			ds = 0.150;			     % Size of diode in millimeters
+			handles.diodesize = ds;
+			handles.diodenum  = 128; % Diode number
+			handles.current_image = 1;
+			probetype=2;
+			% TAS file info - Added by Joe Finlon - 03/03/17
+			tasFile = varargin{1};
+			tas = ncread(tasFile, 'TAS'); % aircraft TAS in m/s
+			tasTime = ncread(tasFile, 'Time'); % aircraft time in HHMMSS
+			disp(['Using TAS data from ', tasFile])
+			
+		case '2DS'
+			boundary=[43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690];
+			boundarytime=0;
+			
+			ds = 0.010;			     % Size of diode in millimeters
+			handles.diodesize = ds;
+			handles.diodenum  = 128; % Diode number
+			handles.current_image = 1;
+			probetype=2;
+			% TAS file info - Added by Joe Finlon - 03/03/17
+			tasFile = varargin{1};
+			tas = ncread(tasFile, 'TAS'); % aircraft TAS in m/s
+			tasTime = ncread(tasFile, 'Time'); % aircraft time in HHMMSS
+			disp(['Using TAS data from ', tasFile])
+	end
+	
+	diodenum = handles.diodenum;
+	byteperslice = diodenum/8;
+	handles.disagree = 0;
+	
+	%% Read the particle image files
+	handles.f = netcdf.open(infile,'nowrite');
+	[~, dimlen] = netcdf.inqDim(handles.f,2);
+	[~, handles.img_count] = netcdf.inqDim(handles.f,0);
+	size_mat = dimlen;
+	warning off all
+	diode_stats = zeros(1,diodenum);
+	
+	
+	%% Create output NETCDF file and variables
+	f = netcdf.create(outfile, 'clobber');
+	dimid0 = netcdf.defDim(f,'time',netcdf.getConstant('NC_UNLIMITED'));
+	dimid1 = netcdf.defDim(f,'pos_count',2);
+	dimid2 = netcdf.defDim(f,'bin_count',diodenum);
+	
+	NC_GLOBAL = netcdf.getConstant('NC_GLOBAL');
+	netcdf.putAtt(f, NC_GLOBAL, 'Software', 'UIOPS/imgProc_sm');
+	netcdf.putAtt(f, NC_GLOBAL, 'Institution', 'Univ. Illinois, Dept. Atmos. Sciences');
+	netcdf.putAtt(f, NC_GLOBAL, 'Creation Time', datestr(now, 'yyyy/mm/dd HH:MM:SS'));
+	netcdf.putAtt(f, NC_GLOBAL, 'Description', ['Contains size, morphological, ',...
+		'and other particle properties from an uncompressed image file.']);
+	netcdf.putAtt(f, NC_GLOBAL, 'Project', projectname);
+	netcdf.putAtt(f, NC_GLOBAL, 'Image Source', infile);
+	netcdf.putAtt(f, NC_GLOBAL, 'Probe Type', probename);
+	if iRectEllipse && calcAllDiodeStats
+		netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active',...
+			'Rectangle & elliptical fits & per-particle diode statistics');
+	elseif iRectEllipse && ~calcAllDiodeStats
+		netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active',...
+			'Rectangle & elliptical fits');
+	elseif ~iRectEllipse && calcAllDiodeStats
+		netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active',...
+			'Per-particle diode statistics');
+	else
+		netcdf.putAtt(f, NC_GLOBAL, 'Optional parameters active', 'None')
+	end
+	
+	
+	varid1 = netcdf.defVar(f,'Date','int',dimid0);
+	netcdf.putAtt(f, varid1, 'Units', 'YYYYMMDD')
+	netcdf.putAtt(f, varid1, 'Description', 'Date of image record in which the particle resides')
+	
+	varid0  = netcdf.defVar(f,'Time','int',dimid0);
+	netcdf.putAtt(f, varid0, 'Units', 'HHMMSS')
+	netcdf.putAtt(f, varid0, 'Description', 'Time (UTC) of image record in which the particle resides')
+	
+	varid2  = netcdf.defVar(f,'msec','short',dimid0);
+	netcdf.putAtt(f, varid2, 'Units', 'ms')
+	netcdf.putAtt(f, varid2, 'Description', 'Sub-second time of image record in which the particle resides')
+	
+	varid101  = netcdf.defVar(f,'Time_in_seconds','double',dimid0);
+	netcdf.putAtt(f, varid101, 'Units', 'sec')
+	netcdf.putAtt(f, varid101, 'Description', 'Time since probe was activated')
+	
+	if probetype~=0 % Added by Joe Finlon - 06/22/17
+		varid102  = netcdf.defVar(f,'SliceCount','short',dimid0); %**TYPE?**
+		netcdf.putAtt(f, varid102, 'Units', '--')
+		netcdf.putAtt(f, varid102, 'Description', 'Number of slices containing particle')
+		
+		varid103  = netcdf.defVar(f,'DMT_DOF_SPEC_OVERLOAD','short',dimid0);
+		netcdf.putAtt(f, varid103, 'Units', '--')
+		netcdf.putAtt(f, varid103, 'Description', 'Flag denoting out-of-focus (DMT) or overloaded (SPEC) particles')
+		
+		varid104  = netcdf.defVar(f,'Particle_number_all','int',dimid0); %**TYPE?** Will we ever exceed ~2 billion particles?
+		netcdf.putAtt(f, varid104, 'Units', '--')
+		netcdf.putAtt(f, varid104, 'Description', 'Index of particle in 2-D buffer')
+	end
+	%varid3 = netcdf.defVar(f,'wkday','double',dimid0);
+	varid4  = netcdf.defVar(f,'position','short',[dimid1 dimid0]);
+	netcdf.putAtt(f, varid4, 'Units', '--')
+	netcdf.putAtt(f, varid4, 'Description', 'Slice within image record where particle is first sampled')
+	
+	varid5  = netcdf.defVar(f,'particle_time','int',dimid0);
+	netcdf.putAtt(f, varid5, 'Units', 'HHMMSS')
+	netcdf.putAtt(f, varid5, 'Description', 'Particle time (not available for 2DS/HVPS)')
+	
+	varid6  = netcdf.defVar(f,'particle_millisec','short',dimid0);
+	netcdf.putAtt(f, varid6, 'Units', 'ms')
+	netcdf.putAtt(f, varid6, 'Description', 'Sub-second particle time (not available for 2DS/HVPS)')
+	
+	varid7  = netcdf.defVar(f,'particle_microsec','double',dimid0);
+	netcdf.putAtt(f, varid7, 'Units', 'microsec')
+	netcdf.putAtt(f, varid7, 'Description', 'Sub-second particle time (unitless clock count for 2DS/HVPS)')
+	
+	varid8  = netcdf.defVar(f,'parent_rec_num','int',dimid0);
+	netcdf.putAtt(f, varid8, 'Units', '--')
+	netcdf.putAtt(f, varid8, 'Description', 'Index of image record in which the particle resides')
+	
+	varid9  = netcdf.defVar(f,'particle_num','short',dimid0);
+	netcdf.putAtt(f, varid9, 'Units', '--')
+	netcdf.putAtt(f, varid9, 'Description', 'Particle index within current image record')
+	
+	varid10 = netcdf.defVar(f,'image_length','short',dimid0);
+	netcdf.putAtt(f, varid10, 'Units', '--')
+	netcdf.putAtt(f, varid10, 'Description', 'Particle length in time direction using # photodiodes')
+	
+	varid11 = netcdf.defVar(f,'image_width','short',dimid0);
+	netcdf.putAtt(f, varid11, 'Units', '--')
+	netcdf.putAtt(f, varid11, 'Description', 'Particle length in photodiode direction using # photodiodes')
+	
+	varid12 = netcdf.defVar(f,'image_area','double',dimid0);
+	netcdf.putAtt(f, varid12, 'Units', 'mm^2')
+	netcdf.putAtt(f, varid12, 'Description', 'Projected area using the # shadowed photodiodes')
+	
+	varid13 = netcdf.defVar(f,'image_longest_y','short',dimid0);
+	netcdf.putAtt(f, varid13, 'Units', '--')
+	netcdf.putAtt(f, varid13, 'Description', 'Longest vertically-oriented chord through particle in time direction')
+	
+	varid14 = netcdf.defVar(f,'image_max_top_edge_touching','short',dimid0);
+	netcdf.putAtt(f, varid14, 'Units', '--')
+	netcdf.putAtt(f, varid14, 'Description', 'Maximum # of times the bottom diode is shadowed in succession')
+	
+	varid15 = netcdf.defVar(f,'image_max_bottom_edge_touching','short',dimid0);
+	netcdf.putAtt(f, varid15, 'Units', '--')
+	netcdf.putAtt(f, varid15, 'Description', 'Maximum # of times the top diode is shadowed in succession')
+	
+	varid16 = netcdf.defVar(f,'image_touching_edge','byte',dimid0);
+	netcdf.putAtt(f, varid16, 'Units', '--')
+	netcdf.putAtt(f, varid16, 'Description', '0 denotes image entirely in array; 1 denotes image touching edge')
+	
+	varid17 = netcdf.defVar(f,'image_auto_reject','short',dimid0);
+	netcdf.putAtt(f, varid17, 'Units', '--')
+	netcdf.putAtt(f, varid17, 'Description', ['ASCII reject code ("0" or 48: accepted; "a" or 97: aspect ratio > 6; ',...
+		'"t" or 116: aspect ratio > 5 + image touching edge; ',...
+		'"p" or 112: < 25% shadowed diodes in rectangle encompassing particle; ',...
+		'"h" or 104 or 72 or 117: hollow particle; "s" or 115: split image; ',...
+		'"z" or 122: zero area image; "f" or 102: zero area image)'])
+	
+	varid18 = netcdf.defVar(f,'image_hollow','byte',dimid0);
+	netcdf.putAtt(f, varid18, 'Units', '--')
+	netcdf.putAtt(f, varid18, 'Description', '0 denotes not hollow; 1 denotes a hollow image')
+	
+	varid19 = netcdf.defVar(f,'image_center_in','byte',dimid0);
+	netcdf.putAtt(f, varid19, 'Units', '--')
+	netcdf.putAtt(f, varid19, 'Description', '0 denotes center of particle outside array; 1 denotes center is inside')
+	
+	varid20 = netcdf.defVar(f,'image_axis_ratio','double',dimid0);
+	netcdf.putAtt(f, varid20, 'Units', '--')
+	netcdf.putAtt(f, varid20, 'Description', 'Ratio between maximum vertical length and maximum horizontal length')
+	
+	varid21 = netcdf.defVar(f,'image_diam_circle_fit','double',dimid0);
+	netcdf.putAtt(f, varid21, 'Units', 'mm')
+	netcdf.putAtt(f, varid21, 'Description', 'Dmax following Heymsfield & Parrish (1978)')
+	
+	varid22 = netcdf.defVar(f,'image_diam_horiz_chord','double',dimid0);
+	netcdf.putAtt(f, varid22, 'Units', 'mm')
+	netcdf.putAtt(f, varid22, 'Description', 'Dmax from # slices+1; best for sideways-looking probes')
+	
+	varid23 = netcdf.defVar(f,'image_diam_horiz_chord_corr','double',dimid0);
+	netcdf.putAtt(f, varid23, 'Units', 'mm')
+	netcdf.putAtt(f, varid23, 'Description', 'Dmax from # slices+1, with Korolev (2007) correction applied to hollow spherical particles')
+	
+	varid24 = netcdf.defVar(f,'image_diam_following_bamex_code','double',dimid0);
+	netcdf.putAtt(f, varid24, 'Units', 'mm')
+	netcdf.putAtt(f, varid24, 'Description', 'Dmax from maximum length chord through the particle')
+	
+	varid25 = netcdf.defVar(f,'image_diam_vert_chord','double',dimid0);
+	netcdf.putAtt(f, varid25, 'Units', 'mm')
+	netcdf.putAtt(f, varid25, 'Description', ['Dmax from maximum length in photodiode direction; ',...
+		'best for sideways-looking probes'])
+	
+	varid26 = netcdf.defVar(f,'image_diam_minR','double',dimid0);
+	netcdf.putAtt(f, varid26, 'Units', 'mm')
+	netcdf.putAtt(f, varid26, 'Description', 'Dmax of smallest circle enclosing the particle')
+	
+	varid27 = netcdf.defVar(f,'image_diam_AreaR','double',dimid0);
+	netcdf.putAtt(f, varid27, 'Units', 'mm')
+	netcdf.putAtt(f, varid27, 'Description', 'Area equivalent diameter')
+	
+	varid45 = netcdf.defVar(f,'image_perimeter','double',dimid0);
+	netcdf.putAtt(f, varid45, 'Units', 'mm')
+	netcdf.putAtt(f, varid45, 'Description', 'Perimeter following the particle boundary')
+	
+	if 1==iRectEllipse
+		varid46 = netcdf.defVar(f,'image_RectangleL','double',dimid0);
+		netcdf.putAtt(f, varid46, 'Units', 'mm')
+		netcdf.putAtt(f, varid46, 'Description', 'Length of smallest rectangle enclosing the particle')
+		
+		varid47 = netcdf.defVar(f,'image_RectangleW','double',dimid0);
+		netcdf.putAtt(f, varid47, 'Units', 'mm')
+		netcdf.putAtt(f, varid47, 'Description', 'Width of smallest rectangle enclosing the particle')
+		
+		varid67 = netcdf.defVar(f,'image_RectangleAngle','double',dimid0);
+		netcdf.putAtt(f, varid67, 'Units', 'radians')
+		netcdf.putAtt(f, varid67, 'Description', 'Angle of rectangle with respect to the time direction')
+		
+		varid48 = netcdf.defVar(f,'image_EllipseL','double',dimid0);
+		netcdf.putAtt(f, varid48, 'Units', 'mm')
+		netcdf.putAtt(f, varid48, 'Description', 'Length of smallest ellipse enclosing the particle')
+		
+		varid49 = netcdf.defVar(f,'image_EllipseW','double',dimid0);
+		netcdf.putAtt(f, varid49, 'Units', 'mm')
+		netcdf.putAtt(f, varid49, 'Description', 'Width of smallest ellipse enclosing the particle')
+		
+		varid69 = netcdf.defVar(f,'image_EllipseAngle','double',dimid0);
+		netcdf.putAtt(f, varid69, 'Units', 'radians')
+		netcdf.putAtt(f, varid69, 'Description', 'Angle of rectangle with respect to the time direction')
+	end
+	varid28 = netcdf.defVar(f,'percent_shadow_area','double',dimid0);
+	netcdf.putAtt(f, varid28, 'Units', 'percent')
+	netcdf.putAtt(f, varid28, 'Description', 'Ratio between the projected area and L*W')
+	
+	varid29 = netcdf.defVar(f,'edge_at_max_hole','short',dimid0);
+	netcdf.putAtt(f, varid29, 'Units', '--')
+	netcdf.putAtt(f, varid29, 'Description', ['# diodes between edges of the particle for the slice ',...
+		'containing the largest gap inside the particle'])
+	
+	varid30 = netcdf.defVar(f,'max_hole_diameter','short',dimid0);
+	netcdf.putAtt(f, varid30, 'Units', '--')
+	netcdf.putAtt(f, varid30, 'Description', 'Diameter of the largest hole inside the particle')
+	
+	varid31 = netcdf.defVar(f,'part_z','double',dimid0);
+	netcdf.putAtt(f, varid31, 'Units', '--')
+	netcdf.putAtt(f, varid31, 'Description', 'Particle depth in object plane calculated via lookup table')
+	
+	varid32 = netcdf.defVar(f,'size_factor','double',dimid0);
+	netcdf.putAtt(f, varid32, 'Units', '--')
+	netcdf.putAtt(f, varid32, 'Description', 'Dmax reduction factor folowing Korolev (2007) correction')
+	
+	varid33 = netcdf.defVar(f,'holroyd_habit','short',dimid0);
+	netcdf.putAtt(f, varid33, 'Units', '--')
+	netcdf.putAtt(f, varid33, 'Description', ['ASCII habit code following the Holroyd (1987) algorithm ',...
+		'("M" or 77: zero image; "C" or 67: center-out image; "t" or 116: tiny; "o" or 111: oriented; ',...
+		'"l" or 108: linear; "a" or 97: aggregate; "g" or 103: graupel; "s" or 115: sphere; ',...
+		'"h" or 104: hexagonal; "i" or 105: irregular; "d" or 100: dendrite)'])
+	
+	varid34 = netcdf.defVar(f,'area_hole_ratio','double',dimid0);
+	netcdf.putAtt(f, varid34, 'Units', '--')
+	netcdf.putAtt(f, varid34, 'Description', 'Ratio between the projected area and the area of hole inside particle')
+	
+	varid35 = netcdf.defVar(f,'inter_arrival','double',dimid0);
+	netcdf.putAtt(f, varid35, 'Units', 'sec')
+	netcdf.putAtt(f, varid35, 'Description', ['Inter-arrival time between particles ',...
+		'(use diff(time_in_seconds) for 2DS/HVPS)'])
+	
+	varid36 = netcdf.defVar(f,'bin_stats','int',dimid2);
+	netcdf.putAtt(f, varid36, 'Units', '--')
+	netcdf.putAtt(f, varid36, 'Description', '# times specified photodiode is shadowed for particles in this file')
+	
+	if calcAllDiodeStats
+		varid37 = netcdf.defVar(f,'image_bin_stats','int',[dimid2 dimid0]);
+		netcdf.putAtt(f, varid37, 'Units', '--')
+		netcdf.putAtt(f, varid37, 'Description', '# times specified photodiode is shadowed for each particle')
+	end
+	
+	netcdf.endDef(f)
+	
+	%% Variables initialization
+	kk=1;
+	w=-1;
+	wstart = 0;
+	
+	time_offset_hr = 0;
+	time_offset_mn = 0;
+	time_offset_sec = 0;
+	time_offset_ms = 0;
+	timeset_flag = 0;
+	
+	% Initialize corrupt record and particle counters - Added by Dan Stechman 8/1/17
+	% Currently, issue is specific to PECAN, but may be present with other DMT data
+	if probetype == 1
+		crptRecCount = 0;
+		crptPartCount = 0;
+	end
+	
+	%% Processing nth chuck. Every chuck is nEvery frame
+	%% Analyze each individual particle images and Outpu the particle by particle information
+	for i=((n-1)*nEvery+1):min(n*nEvery,handles.img_count)
+		
+		handles.year     = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'year'    ),i-1,1);
+		handles.month    = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'month'  ),i-1,1);
+		handles.day      = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'day'  ),i-1,1);
+		handles.hour     = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'hour'    ),i-1,1);
+		handles.minute   = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'minute'  ),i-1,1);
+		handles.second   = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'second'  ),i-1,1);
+		handles.millisec = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'millisec'),i-1,1);
+		
+		if mod(i,100) == 0
+			disp([num2str(i),'/',num2str(handles.img_count), ', ',datestr(now)])
+		end
+		varid = netcdf.inqVarID(handles.f,'data');
+		
+		if probetype==0
+			temp = netcdf.getVar(handles.f,varid,[0, 0, i-1], [4,1024,1]);
+		else
+			temp = netcdf.getVar(handles.f,varid,[0, 0, i-1], [8,1700,1]);
+		end
+		data(:,:) = temp';
+		
+		j=1;
+		start=0;
+		firstpart = 1;
+		
+		% Check the current data record for corrupt boundaries and keep track
+		% of which and how many records and particles are being dicarded
+		% May be PECAN-specific, but should be tested with other DMT probe data - Added by Dan Stechman 8/1/17
+		if probetype == 1
+			tempMmbr = ismember(data,boundary);
+			goodBnd = [1,1,1,1,1,1,1,1];
+			crptBnd = [0,1,1,1,1,1,1,1];
+			numCrptBnds = length(find(ismember(tempMmbr,crptBnd,'rows')));
+			numGoodBnds = length(find(ismember(tempMmbr,goodBnd,'rows')));
+
+			if numCrptBnds > 0
+				fprintf('%d/%d boundaries in record %d are corrupt.\n',numCrptBnds,numGoodBnds+numCrptBnds,i);
+				crptRecCount = crptRecCount + 1;
+				crptPartCount = crptPartCount + (numGoodBnds + numCrptBnds);
+			end
+		end
+		
+		%c=[dec2bin(data(:,1),8),dec2bin(data(:,2),8),dec2bin(data(:,3),8),dec2bin(data(:,4),8)];
+		while data(j,1) ~= -1 && j < size(data,1) && numCrptBnds < 1
+			% Calculate every particles
+			if (isequal(data(j,:), boundary) && ( (isequal(data(j+1,1), boundarytime) || probetype==1) ) )
+				if start == 0
+					if probetype == 0 || probetype == 1
+						start = 2;
+					else
+						start = 1;
+					end
+				end
+				
+				if probetype == 0
+					if start+1 > (j-1)  % Remove Corrupted Data
+						break;
+					end
+				else
+					if start > (j-1)  % Remove Corrupted Data
+						break;
+					end
+				end
+				
+				header_loc = j+1;
+				w=w+1;
+				%% Create binary image according to probe type
+				
+				if probetype==0
+					ind_matrix(1:j-start-1,:) = data(start+1:j-1,:);  % 2DC has 3 slices between particles (sync word timing word and end of particle words)
+					c=[dec2bin(ind_matrix(:,1),8),dec2bin(ind_matrix(:,2),8),dec2bin(ind_matrix(:,3),8),dec2bin(ind_matrix(:,4),8)];
+				elseif probetype==1
+					ind_matrix(1:j-start,:) = data(start:j-1,:);
+					c=[dec2bin(ind_matrix(:,1),8), dec2bin(ind_matrix(:,2),8),dec2bin(ind_matrix(:,3),8),dec2bin(ind_matrix(:,4),8), ...
+						dec2bin(ind_matrix(:,5),8), dec2bin(ind_matrix(:,6),8),dec2bin(ind_matrix(:,7),8),dec2bin(ind_matrix(:,8),8)];
+				elseif probetype==2
+					ind_matrix(1:j-start,:) = 65535 - data(start:j-1,:); % I used 1 to indicate the illuminated doides for HVPS
+					c=[dec2bin(ind_matrix(:,1),16), dec2bin(ind_matrix(:,2),16),dec2bin(ind_matrix(:,3),16),dec2bin(ind_matrix(:,4),16), ...
+						dec2bin(ind_matrix(:,5),16), dec2bin(ind_matrix(:,6),16),dec2bin(ind_matrix(:,7),16),dec2bin(ind_matrix(:,8),16)];
+				end
+				
+				% Just to test if there are bad images, usually 0 area images
+				figsize = size(c);
+				if figsize(2)~=diodenum
+					disp('Not equal to doide number');
+					return
+				end
+				
+				
+				images.position(kk,:) = [start, j-1];
+				parent_rec_num(kk)=i;
+				particle_num(kk) = mod(kk,66536); %hex2dec([dec2hex(data(start-1,7)),dec2hex(data(start-1,8))]);
+				
+				%  Get the particle time
+				if probetype == 0
+					bin_convert = [dec2bin(data(header_loc,2),8),dec2bin(data(header_loc,3),8),dec2bin(data(header_loc,4),8)];
+					part_time = bin2dec(bin_convert);       % Interarrival time in tas clock cycles
+					tas2d = netcdf.getVar(handles.f,netcdf.inqVarID(handles.f,'tas'),i-1, 1);
+					part_time = part_time/tas2d*handles.diodesize/(10^3);
+					time_in_seconds(kk) = part_time;
+					
+					images.int_arrival(kk) = part_time;
+					
+					if(firstpart == 1)
+						firstpart = 0;
+						start_hour = handles.hour;
+						start_minute = handles.minute;
+						start_second = handles.second;
+						start_msec = handles.millisec*10;
+						% First, we get the hours....
+						start_msec = start_msec;
+						start_microsec = 0;
+						time_offset_hr = 0;
+						time_offset_mn = 0;
+						time_offset_sec = 0;
+						time_offset_ms = 0;
 						
-						time_in_seconds(kk) = time_in_seconds(kk) + TimeOffsetSec;
+						part_hour(kk) = start_hour;
+						part_min(kk) = start_minute;
+						part_sec(kk) = start_second;
+						part_mil(kk) = start_msec;
+						part_micro(kk) = 0;
+					else
+						frac_time = part_time - floor(part_time);
+						frac_time = frac_time * 1000;
+						part_micro(kk) = part_micro(kk-1) + (frac_time - floor(frac_time))*1000;
+						part_mil(kk) = part_mil(kk-1) + floor(frac_time);
+						part_sec(kk) = part_sec(kk-1) + floor(part_time);
+						part_min(kk) = part_min(kk-1);
+						part_hour(kk) = part_hour(kk-1);
+					end
+					
+					part_sec(part_mil >= 1000) = part_sec(part_mil >= 1000) + 1;
+					part_mil(part_mil >= 1000) = part_mil(part_mil >= 1000) - 1000;
+					
+					part_min(part_sec >= 60) = part_min(part_sec >= 60) + 1;
+					part_sec(part_sec >= 60) = part_sec(part_sec >= 60) - 60;
+					
+					part_hour(part_min >= 60) = part_hour(part_min >= 60) + 1;
+					part_min(part_min >= 60) = part_min(part_min >= 60) - 60;
+					part_hour(part_hour >= 24) = part_hour(part_hour >= 24) - 24;
+				
+				elseif probetype == 1
+					bin_convert = [dec2bin(data(start-1,2),8),dec2bin(data(start-1,3),8),dec2bin(data(start-1,4),8), ...
+						dec2bin(data(start-1,5),8), dec2bin(data(start-1,6),8)];
+					
+					part_hour(kk) = bin2dec(bin_convert(1:5));
+					part_min(kk) = bin2dec(bin_convert(6:11));
+					part_sec(kk) = bin2dec(bin_convert(12:17));
+					part_mil(kk) = bin2dec(bin_convert(18:27));
+					part_micro(kk) = bin2dec(bin_convert(28:40))*125e-9;
+					
+					% Apply time correction to PIP probe-time for slect PECAN flights - Added by Dan Stechman 8/1/17
+					if strcmp(projectname, 'PECAN') && strcmp(probename, 'PIP')
+						if (handles.month == 6 && handles.day == 17)
+							part_hour_offset = -12;
+							part_min_offset = 0;
+							part_sec_offset = 0;
+						elseif (handles.month == 6 && handles.day == 20) % Time offset was corrected during flight after 6 UTC
+							if handles.hour < 6
+								part_hour_offset = -12;
+								part_min_offset = 0;
+								part_sec_offset = 0;
+							else
+								part_hour_offset = 0;
+								part_min_offset = 0;
+								part_sec_offset = 0;
+							end
+						elseif (handles.month == 7 && (handles.day >= 6 && handles.day <= 13))
+							part_hour_offset = -12;
+							part_min_offset = 0;
+							part_sec_offset = 0;
+						else
+							part_hour_offset = 0;
+							part_min_offset = 0;
+							part_sec_offset = 0;
+						end
+						
+						
 						part_hour(kk) = part_hour(kk) + part_hour_offset;
 						part_min(kk) = part_min(kk) + part_min_offset;
 						part_sec(kk) = part_sec(kk) + part_sec_offset;
 						
-						%fprintf('Time in seconds after correction: %d\n',time_in_seconds(kk));
-						%fprintf('Particle hour after correction: %d\n',part_hour(kk));
-						%fprintf('Particle minute after correction: %d\n',part_min(kk));
-						%fprintf('Particle sec after correction: %d\n',part_sec(kk));
 					end
-					%}
 					
-                    if kk > 1
-                        images.int_arrival(kk) = time_in_seconds(kk) - time_in_seconds(kk-1);
-                    else
-                        images.int_arrival(kk) = time_in_seconds(kk);
-                    end
-
-
-                elseif probetype==2
-
-                    particle_DOF(kk)=bitand(data(header_loc,4), 32768);
-                    particle_partNum(kk)=double(data(header_loc,5));
-                    particle_sliceCount(kk)=double(data(header_loc,6));
-
-                    part_time = double(data(header_loc,7))*2^16+double(data(header_loc,8));       % Interarrival time in clock cycles
-                    part_micro(kk) = part_time;
-                    part_mil(kk)   = 0;
-                    part_sec(kk)   = 0;
-                    part_min(kk)   = 0;
-                    part_hour(kk)  = 0;
-                    
-                    % -----------------------------------------------------
-                    % calculate the particle time (in seconds) - Added by Joe Finlon - 03/03/17
-                    tempTime = double(handles.hour)*10000+double(handles.minute)*100+double(handles.second); % image record time in HHMMSS
-                    tas2d = tas(tasTime==tempTime); % get TAS for corresponding time period
-                    
-                    if exist('part_time_prev', 'var')
-                        if isempty(tas2d) % use when no TAS data is available for current time
-                            % compute time difference (sec) between
-                            % particles to determine whether corrections
-                            % are needed (see 'indexRollback' in
-                            % sizeDist.m)
-                            timeDiff = (part_time-part_time_prev)*(handles.diodesize/(10^3)/170);
-                            
-                            if timeDiff>=-250 % clock cycle hasn't rolled back
-                                time_in_seconds(kk) = time_in_seconds_prev + timeDiff;
-                            else % perform correction when clock cycle exceeds 2^32 and rolls back
-                                time_in_seconds(kk) = time_in_seconds_prev + (2^32-1-part_time_prev+part_time)*...
-                                    (handles.diodesize/(10^3)/170);
-                                disp(['Performing clock cyle time correction. ',num2str(part_time_prev),...
-                                    ' ',num2str(part_time),' ',num2str(time_in_seconds_prev),' ',num2str(time_in_seconds(kk))])
-                            end
-                        else % use the TAS to convert clock cycles to time
-                            % compute time difference (sec) between
-                            % particles to determine whether corrections
-                            % are needed (see 'indexRollback' in
-                            % sizeDist.m)
-                            timeDiff = (part_time-part_time_prev)*(handles.diodesize/(10^3)/tas2d);
-                            
-                            if timeDiff>=-250 % clock cycle hasn't rolled back
-                                time_in_seconds(kk) = time_in_seconds_prev + timeDiff;
-                            else % perform correction when TAS clock cycle exceeds 2^32 and rolls back
-                                time_in_seconds(kk) = time_in_seconds_prev + (2^32-1-part_time_prev+part_time)*...
-                                    (handles.diodesize/(10^3)/tas2d);
-                                disp(['Performing clock cyle time correction. ',num2str(part_time_prev),...
-                                    ' ',num2str(part_time),' ',num2str(time_in_seconds_prev),' ',num2str(time_in_seconds(kk))])
-                            end
-                        end
-                    else % run for the first particle in data file
-                        if isempty(tas2d)
-                            time_in_seconds(kk) = part_time*(handles.diodesize/(10^3)/170);
-                        else
-                            time_in_seconds(kk) = part_time*(handles.diodesize/(10^3)/tas2d);
-                        end
-                    end
-                    
-                    if(kk>1) % ** Use diff(time_in_seconds) to compute int-arr time in post-processing **
-                        images.int_arrival(kk) = time_in_seconds(kk)-time_in_seconds(kk-1);
-                    else
-                        images.int_arrival(kk) = 0;
-                    end
-                    
-                    part_time_prev = part_time; % assign the clock cycle for use in next iteration
-                    time_in_seconds_prev = time_in_seconds(kk);
-                    % -----------------------------------------------------
-                end
-                
-                temptimeinhhmmss = part_hour(kk) * 10000 + part_min(kk) * 100 + part_sec(kk);
-                %if (temptimeinhhmmss<200000 || temptimeinhhmmss>240000)
-                %    temptimeinhhmmss
-                %end
-                
-                slices_ver = length(start:j-1);
-                rec_time(kk)=double(handles.hour)*10000+double(handles.minute)*100+double(handles.second);
-                rec_date(kk)=double(handles.year)*10000+double(handles.month)*100+double(handles.day);
-                rec_millisec(kk)=handles.millisec;
-                %                 rec_wkday(kk)=handles.wkday(i);
-   
-                %% Determine the Particle Habit
-                %  We use the Holroyd algorithm here
-                handles.bits_per_slice = diodenum;
-                if calcAllDiodeStats
-                    images.diode_stats(kk,:) = sum(c=='0',1); % Option to save diode stats for every particle
-                end
-                diode_stats = diode_stats + sum(c=='0',1);
-                csum = sum(c=='0',1);
-
-                images.holroyd_habit(kk) = holroyd(handles,c);
-                
-                %% Determine if the particle is rejected or not
-                %  Calculate the Particle Length, Width, Area, Auto Reject 
-                %  Status And more... See calculate_reject_unified()
-                %  funtion for more information
-                
-                [images.image_length(kk),images.image_width(kk),images.image_area(kk), ...
-                    images.longest_y_within_a_slice(kk),images.max_top_edge_touching(kk),images.max_bottom_edge_touching(kk),...
-                    images.image_touching_edge(kk), images.auto_reject(kk),images.is_hollow(kk),images.percent_shadow(kk),images.part_z(kk),...
-                    images.sf(kk),images.area_hole_ratio(kk),handles]=calculate_reject_unified(c,handles,images.holroyd_habit(kk));
-
-                images.max_hole_diameter(kk) = handles.max_hole_diameter;
-                images.edge_at_max_hole(kk) = handles.edge_at_max_hole;
-
-                max_horizontal_length = images.image_length(kk);
-                max_vertical_length = images.longest_y_within_a_slice(kk);
-                image_area = images.image_area(kk);
-
-                diode_size= handles.diodesize;
-                corrected_horizontal_diode_size = handles.diodesize;
-                largest_edge_touching  = max(images.max_top_edge_touching(kk), images.max_bottom_edge_touching(kk));
-                smallest_edge_touching = min(images.max_top_edge_touching(kk), images.max_bottom_edge_touching(kk));
-
-                %% Calculate more size deciptor using more advanced techniques
-                %  See dropsize for more information
-                [images.center_in(kk),images.axis_ratio(kk),images.diam_circle_fit(kk),images.diam_horiz_chord(kk),images.diam_vert_chord(kk),...
-                    images.diam_horiz_mean(kk), images.diam_spheroid(kk)]=dropsize(max_horizontal_length,max_vertical_length,image_area...
-                    ,largest_edge_touching,smallest_edge_touching,diode_size,corrected_horizontal_diode_size, diodenum);
-                
-                %% Calculate size deciptor using bamex code
-                %  See dropsize_new for more information
-                % images.diam_bamex(kk) = dropsize_new(c, largest_edge_touching, smallest_edge_touching, diodenum, corrected_horizontal_diode_size, handles.diodesize, max_vertical_length);
-                
-                %% Using OpenCV C program to calculate length, width and radius. This                 
-                %% Get diameter of the smallest-enclosing circle, rectangle and ellipse
-                %images.minR(kk)=particlesize_cgal(c);
-                images.minR(kk)=CGAL_minR(c);
-                images.AreaR(kk)=2*sqrt(images.image_area(kk)/3.1415926);  % Calculate the Darea (area-equivalent diameter)
-                images.Perimeter(kk)=ParticlePerimeter(c);
-                
-                if 1==iRectEllipse 
-                    [images.RectangleL(kk), images.RectangleW(kk), images.RectangleAngle(kk)] = CGAL_RectSize(c);
-                    [images.EllipseL(kk), images.EllipseW(kk), images.EllipseAngle(kk)]       = CGAL_EllipseSize(c);
-                end
-                %% Get the area ratio using the DL=max(DT,DP), only observed area are used
-                if images.image_length(kk) > images.image_width(kk)
-                    images.percent_shadow(kk) = images.image_area(kk) / (pi * images.image_length(kk).^ 2 / 4);
-                elseif images.image_width(kk) ~= 0
-                    images.percent_shadow(kk) = images.image_area(kk) / (pi * images.image_width(kk).^ 2 / 4);
-                else
-                    images.percent_shadow(kk) = 0;
-                end
-
-                start = j + 2;
-                kk = kk + 1;
-                clear c ind_matrix
-           %end
-        end
-
-        j = j + 1;
-    end
-
-    %% Write out the processed information on NETCDF
-    if kk > 1
-        
-       
-        netcdf.putVar ( f, varid0, wstart, w-wstart+1, rec_time(:) );
-        netcdf.putVar ( f, varid1, wstart, w-wstart+1, rec_date(:) );
-        
-        netcdf.putVar ( f, varid101, wstart, w-wstart+1, time_in_seconds(:) );
-        if probetype~=0 % Added by Joe Finlon - 06/22/17
-            netcdf.putVar ( f, varid102, wstart, w-wstart+1, particle_sliceCount );
-            netcdf.putVar ( f, varid103, wstart, w-wstart+1, particle_DOF );
-            netcdf.putVar ( f, varid104, wstart, w-wstart+1, particle_partNum );
-        end
-        
-        netcdf.putVar ( f, varid2, wstart, w-wstart+1, rec_millisec(:) );
-        %netcdf.putVar ( f, varid3, wstart, w-wstart+1, rec_wkday(:) );
-        netcdf.putVar ( f, varid4, [0 wstart], [2 w-wstart+1], images.position' );
-        netcdf.putVar ( f, varid5, wstart, w-wstart+1, part_hour(:)*10000+part_min(:)*100+part_sec(:) );
-        netcdf.putVar ( f, varid6, wstart, w-wstart+1, part_mil(:) );
-        netcdf.putVar ( f, varid7, wstart, w-wstart+1, part_micro(:) );
-        netcdf.putVar ( f, varid8, wstart, w-wstart+1, parent_rec_num );    
-        netcdf.putVar ( f, varid9, wstart, w-wstart+1, particle_num(:) );
-        netcdf.putVar ( f, varid10, wstart, w-wstart+1, images.image_length);                         
-        netcdf.putVar ( f, varid11, wstart, w-wstart+1, images.image_width);                          
-        netcdf.putVar ( f, varid12, wstart, w-wstart+1, images.image_area*diode_size*diode_size);                           
-        netcdf.putVar ( f, varid13, wstart, w-wstart+1, images.longest_y_within_a_slice);             
-        netcdf.putVar ( f, varid14, wstart, w-wstart+1, images.max_top_edge_touching);                
-        netcdf.putVar ( f, varid15, wstart, w-wstart+1, images.max_bottom_edge_touching); 
-        netcdf.putVar ( f, varid16, wstart, w-wstart+1, images.image_touching_edge-'0');                  
-        netcdf.putVar ( f, varid17, wstart, w-wstart+1, double(images.auto_reject));                  
-        netcdf.putVar ( f, varid18, wstart, w-wstart+1, images.is_hollow);                            
-        netcdf.putVar ( f, varid19, wstart, w-wstart+1, images.center_in);                            
-        netcdf.putVar ( f, varid20, wstart, w-wstart+1, images.axis_ratio);                           
-        netcdf.putVar ( f, varid21, wstart, w-wstart+1, images.diam_circle_fit);                      
-        netcdf.putVar ( f, varid22, wstart, w-wstart+1, images.diam_horiz_chord);                     
-        netcdf.putVar ( f, varid23, wstart, w-wstart+1, images.diam_horiz_chord ./ images.sf);        
-        netcdf.putVar ( f, varid24, wstart, w-wstart+1, images.diam_horiz_mean);              
-        netcdf.putVar ( f, varid25, wstart, w-wstart+1, images.diam_vert_chord);                           
-        netcdf.putVar ( f, varid26, wstart, w-wstart+1, images.minR*diode_size);                      
-        netcdf.putVar ( f, varid27, wstart, w-wstart+1, images.AreaR*diode_size);       
-        netcdf.putVar ( f, varid45, wstart, w-wstart+1, images.Perimeter*diode_size); 
-        if 1==iRectEllipse 
-            netcdf.putVar ( f, varid46, wstart, w-wstart+1, images.RectangleL*diode_size);                      
-            netcdf.putVar ( f, varid47, wstart, w-wstart+1, images.RectangleW*diode_size);         
-            netcdf.putVar ( f, varid67, wstart, w-wstart+1, images.RectangleAngle);         
-            netcdf.putVar ( f, varid48, wstart, w-wstart+1, images.EllipseL*diode_size);                      
-            netcdf.putVar ( f, varid49, wstart, w-wstart+1, images.EllipseW*diode_size); 
-            netcdf.putVar ( f, varid69, wstart, w-wstart+1, images.EllipseAngle); 
-        end
-        netcdf.putVar ( f, varid28, wstart, w-wstart+1, images.percent_shadow);                       
-        netcdf.putVar ( f, varid29, wstart, w-wstart+1, images.max_hole_diameter);                    
-        netcdf.putVar ( f, varid30, wstart, w-wstart+1, images.edge_at_max_hole);                     
-        netcdf.putVar ( f, varid31, wstart, w-wstart+1, images.part_z);                               
-        netcdf.putVar ( f, varid32, wstart, w-wstart+1, images.sf);                                   
-        netcdf.putVar ( f, varid33, wstart, w-wstart+1, double(images.holroyd_habit));                
-        netcdf.putVar ( f, varid34, wstart, w-wstart+1, images.area_hole_ratio);                      
-        netcdf.putVar ( f, varid35, wstart, w-wstart+1, images.int_arrival);                          
-        netcdf.putVar ( f, varid36, diode_stats );
-        if calcAllDiodeStats
-            netcdf.putVar ( f, varid37, [0 wstart], [diodenum w-wstart+1], images.diode_stats' ); % Option to save diode stats for every particle
-        end
-        
-        wstart = w+1;
-        kk = 1;
-        clear rec_time rec_date rec_millisec part_hour part_min part_sec part_mil part_micro parent_rec_num particle_num images time_in_seconds particle_sliceCount particle_DOF particle_partNum
-
-    end
-    clear images
-    firstTime = 0; % Only used when probe time offset correction is applied (PECAN)
-end
-warning on all
-
-netcdf.close(f);
+					particle_sliceCount(kk)=bitand(data(start-1,1),127);
+					particle_DOF(kk)=bitand(data(start-1,1),128);
+					particle_partNum(kk)=bin2dec([dec2bin(data(start-1,7),8),dec2bin(data(start-1,8),8)]);
+					
+					time_in_seconds(kk) = part_hour(kk) * 3600 + part_min(kk) * 60 + part_sec(kk) + part_mil(kk)/1000 + part_micro(kk);
+					
+					
+					if kk > 1
+						images.int_arrival(kk) = time_in_seconds(kk) - time_in_seconds(kk-1);
+					else
+						images.int_arrival(kk) = 0;
+					end
+					
+					
+				elseif probetype==2
+					
+					particle_DOF(kk)=bitand(data(header_loc,4), 32768);
+					particle_partNum(kk)=double(data(header_loc,5));
+					particle_sliceCount(kk)=double(data(header_loc,6));
+					
+					part_time = double(data(header_loc,7))*2^16+double(data(header_loc,8));       % Interarrival time in clock cycles
+					part_micro(kk) = part_time;
+					part_mil(kk)   = 0;
+					part_sec(kk)   = 0;
+					part_min(kk)   = 0;
+					part_hour(kk)  = 0;
+					
+					% -----------------------------------------------------
+					% calculate the particle time (in seconds) - Added by Joe Finlon - 03/03/17
+					tempTime = double(handles.hour)*10000+double(handles.minute)*100+double(handles.second); % image record time in HHMMSS
+					tas2d = tas(tasTime==tempTime); % get TAS for corresponding time period
+					
+					if exist('part_time_prev', 'var')
+						if isempty(tas2d) % use when no TAS data is available for current time
+							% compute time difference (sec) between
+							% particles to determine whether corrections
+							% are needed (see 'indexRollback' in
+							% sizeDist.m)
+							timeDiff = (part_time-part_time_prev)*(handles.diodesize/(10^3)/170);
+							
+							if timeDiff>=-250 % clock cycle hasn't rolled back
+								time_in_seconds(kk) = time_in_seconds_prev + timeDiff;
+							else % perform correction when clock cycle exceeds 2^32 and rolls back
+								time_in_seconds(kk) = time_in_seconds_prev + (2^32-1-part_time_prev+part_time)*...
+									(handles.diodesize/(10^3)/170);
+								disp(['Performing clock cyle time correction. ',num2str(part_time_prev),...
+									' ',num2str(part_time),' ',num2str(time_in_seconds_prev),' ',num2str(time_in_seconds(kk))])
+							end
+						else % use the TAS to convert clock cycles to time
+							% compute time difference (sec) between
+							% particles to determine whether corrections
+							% are needed (see 'indexRollback' in
+							% sizeDist.m)
+							timeDiff = (part_time-part_time_prev)*(handles.diodesize/(10^3)/tas2d);
+							
+							if timeDiff>=-250 % clock cycle hasn't rolled back
+								time_in_seconds(kk) = time_in_seconds_prev + timeDiff;
+							else % perform correction when TAS clock cycle exceeds 2^32 and rolls back
+								time_in_seconds(kk) = time_in_seconds_prev + (2^32-1-part_time_prev+part_time)*...
+									(handles.diodesize/(10^3)/tas2d);
+								disp(['Performing clock cyle time correction. ',num2str(part_time_prev),...
+									' ',num2str(part_time),' ',num2str(time_in_seconds_prev),' ',num2str(time_in_seconds(kk))])
+							end
+						end
+					else % run for the first particle in data file
+						if isempty(tas2d)
+							time_in_seconds(kk) = part_time*(handles.diodesize/(10^3)/170);
+						else
+							time_in_seconds(kk) = part_time*(handles.diodesize/(10^3)/tas2d);
+						end
+					end
+					
+					if(kk>1) % ** Use diff(time_in_seconds) to compute int-arr time in post-processing **
+						images.int_arrival(kk) = time_in_seconds(kk)-time_in_seconds(kk-1);
+					else
+						images.int_arrival(kk) = 0;
+					end
+					
+					part_time_prev = part_time; % assign the clock cycle for use in next iteration
+					time_in_seconds_prev = time_in_seconds(kk);
+					% -----------------------------------------------------
+				end
+				
+				temptimeinhhmmss = part_hour(kk) * 10000 + part_min(kk) * 100 + part_sec(kk);
+				%                 if (temptimeinhhmmss<0 || temptimeinhhmmss>240000)
+				%                    fprintf('%d\n',temptimeinhhmmss);
+				%                 end
+				
+				slices_ver = length(start:j-1);
+				rec_time(kk)=double(handles.hour)*10000+double(handles.minute)*100+double(handles.second);
+				rec_date(kk)=double(handles.year)*10000+double(handles.month)*100+double(handles.day);
+				rec_millisec(kk)=handles.millisec;
+				%                 rec_wkday(kk)=handles.wkday(i);
+				
+				
+				% % 				if mod(i,100) == 0
+				% % 					fprintf('\trecord time - particle time = %.3f\n',(hhmmss2insec(rec_time(kk))-time_in_seconds(kk)));
+				% % 				end
+				
+				
+				%% Determine the Particle Habit
+				%  We use the Holroyd algorithm here
+				handles.bits_per_slice = diodenum;
+				if calcAllDiodeStats
+					images.diode_stats(kk,:) = sum(c=='0',1); % Option to save diode stats for every particle
+				end
+				diode_stats = diode_stats + sum(c=='0',1);
+				csum = sum(c=='0',1);
+				
+				images.holroyd_habit(kk) = holroyd(handles,c);
+				
+				%% Determine if the particle is rejected or not
+				%  Calculate the Particle Length, Width, Area, Auto Reject
+				%  Status And more... See calculate_reject_unified()
+				%  funtion for more information
+				
+				[images.image_length(kk),images.image_width(kk),images.image_area(kk), ...
+					images.longest_y_within_a_slice(kk),images.max_top_edge_touching(kk),images.max_bottom_edge_touching(kk),...
+					images.image_touching_edge(kk), images.auto_reject(kk),images.is_hollow(kk),images.percent_shadow(kk),images.part_z(kk),...
+					images.sf(kk),images.area_hole_ratio(kk),handles]=calculate_reject_unified(c,handles,images.holroyd_habit(kk));
+				
+				images.max_hole_diameter(kk) = handles.max_hole_diameter;
+				images.edge_at_max_hole(kk) = handles.edge_at_max_hole;
+				
+				max_horizontal_length = images.image_length(kk);
+				max_vertical_length = images.longest_y_within_a_slice(kk);
+				image_area = images.image_area(kk);
+				
+				diode_size= handles.diodesize;
+				corrected_horizontal_diode_size = handles.diodesize;
+				largest_edge_touching  = max(images.max_top_edge_touching(kk), images.max_bottom_edge_touching(kk));
+				smallest_edge_touching = min(images.max_top_edge_touching(kk), images.max_bottom_edge_touching(kk));
+				
+				%% Calculate more size deciptor using more advanced techniques
+				%  See dropsize for more information
+				[images.center_in(kk),images.axis_ratio(kk),images.diam_circle_fit(kk),images.diam_horiz_chord(kk),images.diam_vert_chord(kk),...
+					images.diam_horiz_mean(kk), images.diam_spheroid(kk)]=dropsize(max_horizontal_length,max_vertical_length,image_area...
+					,largest_edge_touching,smallest_edge_touching,diode_size,corrected_horizontal_diode_size, diodenum);
+				
+				%% Calculate size deciptor using bamex code
+				%  See dropsize_new for more information
+				% images.diam_bamex(kk) = dropsize_new(c, largest_edge_touching, smallest_edge_touching, diodenum, corrected_horizontal_diode_size, handles.diodesize, max_vertical_length);
+				
+				%% Using OpenCV C program to calculate length, width and radius. This
+				%% Get diameter of the smallest-enclosing circle, rectangle and ellipse
+				%images.minR(kk)=particlesize_cgal(c);
+				images.minR(kk)=CGAL_minR(c);
+				images.AreaR(kk)=2*sqrt(images.image_area(kk)/3.1415926);  % Calculate the Darea (area-equivalent diameter)
+				images.Perimeter(kk)=ParticlePerimeter(c);
+				
+				if 1==iRectEllipse
+					[images.RectangleL(kk), images.RectangleW(kk), images.RectangleAngle(kk)] = CGAL_RectSize(c);
+					[images.EllipseL(kk), images.EllipseW(kk), images.EllipseAngle(kk)]       = CGAL_EllipseSize(c);
+				end
+				%% Get the area ratio using the DL=max(DT,DP), only observed area are used
+				if images.image_length(kk) > images.image_width(kk)
+					images.percent_shadow(kk) = images.image_area(kk) / (pi * images.image_length(kk).^ 2 / 4);
+				elseif images.image_width(kk) ~= 0
+					images.percent_shadow(kk) = images.image_area(kk) / (pi * images.image_width(kk).^ 2 / 4);
+				else
+					images.percent_shadow(kk) = 0;
+				end
+				
+				start = j + 2;
+				kk = kk + 1;
+				clear c ind_matrix
+			end
+			
+			j = j + 1;
+		end
+		
+		%% Write out the processed information on NETCDF
+		if kk > 1
+			
+			
+			netcdf.putVar ( f, varid0, wstart, w-wstart+1, rec_time(:) );
+			netcdf.putVar ( f, varid1, wstart, w-wstart+1, rec_date(:) );
+			
+			netcdf.putVar ( f, varid101, wstart, w-wstart+1, time_in_seconds(:) );
+			if probetype~=0 % Added by Joe Finlon - 06/22/17
+				netcdf.putVar ( f, varid102, wstart, w-wstart+1, particle_sliceCount );
+				netcdf.putVar ( f, varid103, wstart, w-wstart+1, particle_DOF );
+				netcdf.putVar ( f, varid104, wstart, w-wstart+1, particle_partNum );
+			end
+			
+			netcdf.putVar ( f, varid2, wstart, w-wstart+1, rec_millisec(:) );
+			%netcdf.putVar ( f, varid3, wstart, w-wstart+1, rec_wkday(:) );
+			netcdf.putVar ( f, varid4, [0 wstart], [2 w-wstart+1], images.position' );
+			netcdf.putVar ( f, varid5, wstart, w-wstart+1, part_hour(:)*10000+part_min(:)*100+part_sec(:) );
+			netcdf.putVar ( f, varid6, wstart, w-wstart+1, part_mil(:) );
+			netcdf.putVar ( f, varid7, wstart, w-wstart+1, part_micro(:) );
+			netcdf.putVar ( f, varid8, wstart, w-wstart+1, parent_rec_num );
+			netcdf.putVar ( f, varid9, wstart, w-wstart+1, particle_num(:) );
+			netcdf.putVar ( f, varid10, wstart, w-wstart+1, images.image_length);
+			netcdf.putVar ( f, varid11, wstart, w-wstart+1, images.image_width);
+			netcdf.putVar ( f, varid12, wstart, w-wstart+1, images.image_area*diode_size*diode_size);
+			netcdf.putVar ( f, varid13, wstart, w-wstart+1, images.longest_y_within_a_slice);
+			netcdf.putVar ( f, varid14, wstart, w-wstart+1, images.max_top_edge_touching);
+			netcdf.putVar ( f, varid15, wstart, w-wstart+1, images.max_bottom_edge_touching);
+			netcdf.putVar ( f, varid16, wstart, w-wstart+1, images.image_touching_edge-'0');
+			netcdf.putVar ( f, varid17, wstart, w-wstart+1, int16(images.auto_reject));
+			netcdf.putVar ( f, varid18, wstart, w-wstart+1, images.is_hollow);
+			netcdf.putVar ( f, varid19, wstart, w-wstart+1, images.center_in);
+			netcdf.putVar ( f, varid20, wstart, w-wstart+1, images.axis_ratio);
+			netcdf.putVar ( f, varid21, wstart, w-wstart+1, images.diam_circle_fit);
+			netcdf.putVar ( f, varid22, wstart, w-wstart+1, images.diam_horiz_chord);
+			netcdf.putVar ( f, varid23, wstart, w-wstart+1, images.diam_horiz_chord ./ images.sf);
+			netcdf.putVar ( f, varid24, wstart, w-wstart+1, images.diam_horiz_mean);
+			netcdf.putVar ( f, varid25, wstart, w-wstart+1, images.diam_vert_chord);
+			netcdf.putVar ( f, varid26, wstart, w-wstart+1, images.minR*diode_size);
+			netcdf.putVar ( f, varid27, wstart, w-wstart+1, images.AreaR*diode_size);
+			netcdf.putVar ( f, varid45, wstart, w-wstart+1, images.Perimeter*diode_size);
+			if 1==iRectEllipse
+				netcdf.putVar ( f, varid46, wstart, w-wstart+1, images.RectangleL*diode_size);
+				netcdf.putVar ( f, varid47, wstart, w-wstart+1, images.RectangleW*diode_size);
+				netcdf.putVar ( f, varid67, wstart, w-wstart+1, images.RectangleAngle);
+				netcdf.putVar ( f, varid48, wstart, w-wstart+1, images.EllipseL*diode_size);
+				netcdf.putVar ( f, varid49, wstart, w-wstart+1, images.EllipseW*diode_size);
+				netcdf.putVar ( f, varid69, wstart, w-wstart+1, images.EllipseAngle);
+			end
+			netcdf.putVar ( f, varid28, wstart, w-wstart+1, images.percent_shadow);
+			netcdf.putVar ( f, varid29, wstart, w-wstart+1, images.max_hole_diameter);
+			netcdf.putVar ( f, varid30, wstart, w-wstart+1, images.edge_at_max_hole);
+			netcdf.putVar ( f, varid31, wstart, w-wstart+1, images.part_z);
+			netcdf.putVar ( f, varid32, wstart, w-wstart+1, images.sf);
+			netcdf.putVar ( f, varid33, wstart, w-wstart+1, int16(images.holroyd_habit));
+			netcdf.putVar ( f, varid34, wstart, w-wstart+1, images.area_hole_ratio);
+			netcdf.putVar ( f, varid35, wstart, w-wstart+1, images.int_arrival);
+			netcdf.putVar ( f, varid36, diode_stats );
+			
+			if calcAllDiodeStats
+				netcdf.putVar ( f, varid37, [0 wstart], [diodenum w-wstart+1], images.diode_stats' ); % Option to save diode stats for every particle
+			end
+			
+			wstart = w+1;
+			kk = 1;
+			clear rec_time rec_date rec_millisec part_hour part_min part_sec part_mil part_micro parent_rec_num particle_num images time_in_seconds particle_sliceCount particle_DOF particle_partNum
+			
+		end
+		clear images
+		
+	end
+	
+	if probetype == 1
+		slicesInChunk = length(((n-1)*nEvery+1):min(n*nEvery,handles.img_count));
+		fprintf('Chunk %d complete -- %d/%d records were likely corrupt (%.4f%%) --> %d potential particles ignored.\n',n,crptRecCount,...
+			slicesInChunk,(crptRecCount/slicesInChunk),crptPartCount);
+	end
+	
+	warning on all
+	
+	netcdf.close(f);
 end

--- a/runImgProc_example.m
+++ b/runImgProc_example.m
@@ -1,0 +1,28 @@
+function runImgProc_sm_PECAN(nSlice, ddate, probe)
+
+inOutDir = '/data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease/';
+
+
+%  nChuck*nEvery shoudl equal the total frame number 
+nChucks=12; % Number of chucks (sepeate files)
+nEvery =floor(nSlice/12)+1; % Size of every chucks. 
+numb=11:10+nChucks;  % Start from 11 to avoid sigle numbers in file name for later convinience
+
+% Assign the number of CPUs for this program
+gcp=parpool(12)        % Assign n CPUs to process
+
+% Choose the start and end of chucks to be processed. Remember you can
+% split the chucks into different programs to process, since matlabpool can
+% only use 8 CPUs at once
+parfor iii=1:nChucks  % iiith chuck will be processed 
+	infile  = [inOutDir 'DIMG.' probe '.' num2str(ddate) '.cdf'];  % Input file
+    outfile = [inOutDir 'proc2.' num2str(ddate) '.' num2str(numb(iii)) '.' probe '.cdf'];	% Output image autoanalysis file
+    imgProc_sm(infile,outfile, probe, iii, nEvery, 'PECAN');  % See imgProc_sm documentation for more information
+end
+
+delete(gcp)
+%matlabpool close
+exit
+
+end
+

--- a/runSizeDistPECAN.m
+++ b/runSizeDistPECAN.m
@@ -1,52 +1,63 @@
-function runSizeDistPECAN(ddate)
+function runSizeDistPECAN(ddate,runCIP,runPIP)
+	
+	% Added this line as MATLAB would not ls properly in -nodisplay mode without it...
+	cd /data/pecan/a/stechma2/pecan/mp-data/UIOPS
+	
+	%runCIP = 1;
+	%runPIP = 1;
+	
+	projectname = 'PECAN';
+		
+	datadate=num2str(ddate);
+	
+	prmsF = ['/data/pecan/a/stechma2/pecan/' datadate '_PECANparams.nc'];
+	
+	%% Run CIP
+	if runCIP
+		clearvars -except ddate runCIP runPIP projectname datadate prmsF
 
-rCIP = 0;
+		tasfilename =  ls('--color=none',['../' num2str(ddate) '/01CIP*.csv']);
+		dirpath = pwd;
+		cipTASf = strtrim([dirpath '/' tasfilename]);
+		loadCIPcsv
+		
+		tas = CIP_True_Air_Speed;
+		timehhmmss=insec2hhmmss(CIP_Time);
+		pres=CIP_Static_Press+CIP_Diff_Press;
+		temp1=CIP_Ambient_Temp;
+		
+		probe='CIP';
+		
+		% Specify the input filename, output filename, true air speed, time (hhmmss), probe name,
+		% Dmax definition, surface area method, pressure and temperature
+		outFile = ['sdistCI.' datadate '.' probe '.cdf']; % Uncompressed netCDF file name
+		inFile =  ['proc2.' datadate '.' probe '.cdf'];
+		
+		sizeDist(inFile,outFile, tas, floor(timehhmmss),probe, 6, 0, pres, temp1, projectname, datadate, 'NONE', prmsF);
+	end
+	
+	%% Run PIP
+	if runPIP
+		clearvars -except ddate runCIP runPIP projectname datadate prmsF
 
-%% Run CIP
-if rCIP == 1 
-clearvars -except ddate
-inst=num2str(ddate);
-%inst = '20150617';
-tasfilename =  '01CIP20150702015858.csv'; %ls('--color=none',['../PECAN/' num2str(ddate) '/01CIP*.csv']);
-dirpath = pwd;
-tasfilename = strtrim([dirpath '/' tasfilename]);
-loadTASinfo
-
-tas = True_Air_Speed;
-timehhmmss=insec2hhmmss(Time);
-pres=Static_Press+Diff_Press;
-temp1=Ambient_Temp;
-
-probe='CIP';
-% Specify the desination file name infilename and diodesize ds in millimeters
-outFile = ['sdistCI.' inst '.' probe '.cdf'];                  	% Input uncompressed netCDF file name
-% Output file name
-inFile =  ['proc2.' inst '.' probe '.cdf'];
-inst
-sizeDist(inFile,outFile, tas, floor(timehhmmss),probe, 6, 0, pres, temp1);
+		inst=num2str(ddate);
+		tasfilename = ls('--color=none',['../' num2str(ddate) '/00PIP*.csv']); %'00PIP20150617005743.csv';
+		dirpath = pwd;
+		pipTASf = strtrim([dirpath '/' tasfilename]);
+		loadPIPcsv
+		
+		tas = PIP_True_Air_Speed;
+		timehhmmss=insec2hhmmss(PIP_Time);
+		pres=PIP_Static_Press+PIP_Diff_Press;
+		temp1=PIP_Ambient_Temp;
+		
+		probe='PIP';
+		
+		% Specify the input filename, output filename, true air speed, time (hhmmss), probe name,
+		% Dmax definition, surface area method, pressure and temperature
+		outFile = ['sdistCI.' inst '.' probe '.cdf'];                  	% Input uncompressed netCDF file name
+		inFile =  ['proc2.' inst '.' probe '.cdf'];
+		
+		sizeDist(inFile,outFile, tas, floor(timehhmmss),probe, 6, 0, pres, temp1, projectname, datadate, 'NONE', prmsF);
+	end
 end
-%% Run PIP
-clearvars -except ddate
-inst=num2str(ddate);
-%inst = '20150617';
-tasfilename = '00PIP20150620005009.csv'; %ls('--color=none',['../PECAN/' num2str(ddate) '/00PIP*.csv']); %'00PIP20150617005743.csv';
-dirpath = pwd;
-tasfilename = strtrim([dirpath '/' tasfilename]);
-loadTASinfo
-
-tas = True_Air_Speed;
-timehhmmss=insec2hhmmss(Time);
-pres=Static_Press+Diff_Press;
-temp1=Ambient_Temp;
-
-probe='PIP';
-% Specify the desination file name infilename and diodesize ds in millimeters
-outFile = ['sdistCI.' inst '.' probe '.cdf'];                  	% Input uncompressed netCDF file name
-% Output file name
-inFile =  ['proc2.TEST.' probe '.cdf'];
-
-sizeDist(inFile,outFile, tas, floor(timehhmmss),probe, 6, 0, pres, temp1,'PECAN1',ddate);
-
-
-end
-

--- a/runSizeDist_example.m
+++ b/runSizeDist_example.m
@@ -1,0 +1,63 @@
+function runSizeDistPECAN(ddate,runCIP,runPIP)
+	
+	% Added this line as MATLAB would not ls properly in -nodisplay mode without it...
+	cd /data/pecan/a/stechma2/pecan/mp-data/IProcessingRelease
+	
+	%runCIP = 1;
+	%runPIP = 1;
+	
+	projectname = 'PECAN';
+		
+	datadate=num2str(ddate);
+	
+	prmsF = ['/data/pecan/a/stechma2/pecan/' datadate '_PECANparams.nc'];
+	
+	%% Run CIP
+	if runCIP
+		clearvars -except ddate runCIP runPIP projectname datadate prmsF
+
+		tasfilename =  ls('--color=none',['../' num2str(ddate) '/01CIP*.csv']);
+		dirpath = pwd;
+		cipTASf = strtrim([dirpath '/' tasfilename]);
+		loadCIPcsv
+		
+		tas = CIP_True_Air_Speed;
+		timehhmmss=insec2hhmmss(CIP_Time);
+		pres=CIP_Static_Press+CIP_Diff_Press;
+		temp1=CIP_Ambient_Temp;
+		
+		probe='CIP';
+		
+		% Specify the input filename, output filename, true air speed, time (hhmmss), probe name,
+		% Dmax definition, surface area method, pressure and temperature
+		outFile = ['sdistCI.' datadate '.' probe '.cdf']; % Uncompressed netCDF file name
+		inFile =  ['proc2.' datadate '.' probe '.cdf'];
+		
+		sizeDist(inFile,outFile, tas, floor(timehhmmss),probe, 6, 0, pres, temp1, projectname, datadate, 'NONE', prmsF);
+	end
+	
+	%% Run PIP
+	if runPIP
+		clearvars -except ddate runCIP runPIP projectname datadate prmsF
+
+		inst=num2str(ddate);
+		tasfilename = ls('--color=none',['../' num2str(ddate) '/00PIP*.csv']); %'00PIP20150617005743.csv';
+		dirpath = pwd;
+		pipTASf = strtrim([dirpath '/' tasfilename]);
+		loadPIPcsv
+		
+		tas = PIP_True_Air_Speed;
+		timehhmmss=insec2hhmmss(PIP_Time);
+		pres=PIP_Static_Press+PIP_Diff_Press;
+		temp1=PIP_Ambient_Temp;
+		
+		probe='PIP';
+		
+		% Specify the input filename, output filename, true air speed, time (hhmmss), probe name,
+		% Dmax definition, surface area method, pressure and temperature
+		outFile = ['sdistCI.' inst '.' probe '.cdf'];                  	% Input uncompressed netCDF file name
+		inFile =  ['proc2.' inst '.' probe '.cdf'];
+		
+		sizeDist(inFile,outFile, tas, floor(timehhmmss),probe, 6, 0, pres, temp1, projectname, datadate, 'NONE', prmsF);
+	end
+end

--- a/sizeDist.m
+++ b/sizeDist.m
@@ -652,8 +652,13 @@ function sizeDist(infile, outfile, tas, timehhmmss, probename, d_choice, SAmetho
 	
 	fprintf('Beginning size distribution calculations and sorting %s\n\n',datestr(now));
 	
+    fprintf('There are a total of %d one sec data points.\n\n',one_sec_dur);
+
 	for i=1:length(tas) 
     
+        if mod(i,1000) == 0
+            fprintf('%d/%d | %s\n',i,one_sec_dur,datestr(now));
+        end
     %     if (int32(timehhmmss(i))>=int32(starttime(jjj)))
         if (eofFlag==0 && int32(timehhmmss(i))>=int32(starttime(jjj))) % Modified by Joe Finlon - 03/03/17
         
@@ -1219,10 +1224,6 @@ function sizeDist(infile, outfile, tas, timehhmmss, probename, d_choice, SAmetho
 			end
 			
 			%% Perform various status and error checks
-			if mod(i,1000) == 0
-				fprintf('%d/%d | %s\n',i,one_sec_dur,datestr(now));
-			end
-			
 			total_one_sec_locs(i) = length(find(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)));
 			time_interval2(i) = sum(int_arr(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)));
 			

--- a/sizeDist.m
+++ b/sizeDist.m
@@ -55,722 +55,767 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function sizeDist(infile, outfile, tas, timehhmmss, probename, d_choice, SAmethod, Pres, Temp, projectname, ddate, varargin)
-iCreateBad = 0; % Default not to output bad particles PSDs and other info
-iCreateAspectRatio = 0; % Default not to process aspect ratio info
-iSaveIntArrSV = 1; % Default not to save inter-arrival and sample volume information
-%% Interarrival threshold file specification
-% Can be implemented if a time-dependent threshold is required - add 'varargin' to arguments in function header above
-
-if length(varargin) == 1
-	iaThreshFile = varargin{1};
-elseif length(varargin)>1
-	display('You have added too many inputs!')
-	iaThreshFile = 'NONE';
-end
-
-
-%% Define input and output files and initialize time variable
-f = netcdf.open(infile,'nowrite');
-mainf = netcdf.create(outfile, 'clobber');
-
-% Fix flight times if they span multiple days - Added by Joe Finlon -
-% 03/03/17
-timehhmmss(find(diff(timehhmmss)<0)+1:end)=...
-    timehhmmss(find(diff(timehhmmss)<0)+1:end) + 240000;
-
-
-% tas_char = num2str(timehhmmss); %Unused
-tas_time = floor(timehhmmss/10000)*3600+floor(mod(timehhmmss,10000)/100)*60+floor(mod(timehhmmss,100));
-% averaging_time = 1;
-
-%% Project-, probe-, and date-specific information
-switch projectname
-    case 'PECAN'
-		switch probename
-            case 'CIP'
-                num_diodes =64;
-                diodesize = 0.025; % units of mm
-                armdst=100.;
-%                 num_bins = 64;
-%                 kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                num_bins=19;
-                kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000; %Array in microns - converted to mm
-                probetype=1;
-                tasMax=200; % Max airspeed that can be sampled without under-sampling (images would appear skewed)
-                
-				applyIntArrThresh = 1;
-					defaultIntArrThresh = 1e-5;
-				reaccptShatrs = 1;
-					reaccptD = 0.5; % Diammeter (in mm) to reaccept if initially flagged as shattered
-					reaccptMaxIA = 2.5e-7;	% Max interarrival time in seconds a particle can have to be reaccepted if 
-											% size criteria are met. Possible definition of this is the time of one slice, so in
-											% this case, with an airspeed of ~100 m/s and a slice of 25 um, this would be 2.5e-7.
-                
-
-				% Get start and end times (in seconds) of spirals; interarrival time thresholds for each spiral
-				[startT, endT, ~, ~, intar_threshold_spirals] = getPECANparams(ddate, probename);
-				
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-				for ix = 1:length(tas_time)
-					for iz = 1:length(startT)
-						if (tas_time(ix) >= startT(iz) && tas_time(ix) < endT(iz))
-							intar_threshold(ix) = intar_threshold_spirals(iz);
-						end
-					end
-				end
-                
-            case 'PIP'
-                num_diodes =64;
-                diodesize = 0.1; %units of mm
-                armdst=260.;
-                num_bins = 64;
-%                 kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                kk=diodesize/2:diodesize:(num_bins+0.6)*diodesize;
-%                 num_bins=19;
-%                 kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-%                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]*4/1000;
-                probetype=1;
-                tasMax=200; 
-                
-				applyIntArrThresh = 1;
-					defaultIntArrThresh = 1e-5;
-				reaccptShatrs = 1;
-					reaccptD = 0.5; % Diammeter (in mm) to reaccept if initially flagged as shattered
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				% Get start and end times (in seconds) of spirals; interarrival time thresholds for each spiral
-				[startT, endT, ~, ~, intar_threshold_spirals] = getPECANparams(ddate, probename);
-				
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-				for ix = 1:length(tas_time)
-					for iz = 1:length(startT)
-						if (tas_time(ix) >= startT(iz) && tas_time(ix) < endT(iz))
-							intar_threshold(ix) = intar_threshold_spirals(iz);
-						end
-					end
-				end
-        end
-        
-    case 'GPM'
-        switch probename
-            case '2DS'
-                num_diodes =128;
-                diodesize = .010;
-                armdst=63.;
-                num_bins =22;
-                kk=[40.0    60.0    80.0   100.0   125.0   150.0   200.0   250.0   300.0   350.0   400.0 ...
-                    475.0   550.0   625.0   700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000;
-                probetype=2;
-                tasMax=170;
-                
-                % Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 1;
-					defaultIntArrThresh = 1e-6;
-				reaccptShatrs = 1;
-					reaccptD = 0.5;
-                    %reaccptMaxIA = 1e-7; % (Slice size [m])/(avg. airspeed [m/s])
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                    
-            case 'CIP'
-                num_diodes =64;
-                diodesize = 0.025; % units of mm
-                armdst=100.;
-                num_bins=19;
-                kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000; %Array in microns - converted to mm
-                probetype=1;
-                tasMax=200; % Max airspeed that can be sampled without under-sampling (images would appear skewed)
-                
-				applyIntArrThresh = 1;
-					defaultIntArrThresh = 1e-6;
-				reaccptShatrs = 1;
-					reaccptD = 0.5; % Diammeter (in mm) to reaccept if initially flagged as shattered
-					reaccptMaxIA = 2.5e-7;	% Max interarrival time in seconds a particle can have to be reaccepted if 
-											% size criteria are met. Possible definition of this is the time of one slice, so in
-											% this case, with an airspeed of ~100 m/s and a slice of 25 um, this would be 2.5e-7.
-                                               
-            case 'HVPS'
-                % For the HVPS
-                num_diodes =128;
-                diodesize = .150;
-                armdst=161.;
-                num_bins = 28;
-                kk=[200.0   400.0   600.0   800.0  1000.0  1200.0  1400.0  1600.0  1800.0  2200.0  2600.0 ...
-                     3000.0  3400.0  3800.0  4200.0  4600.0  5000.0  6000.0  7000.0  8000.0  9000.0 10000.0 ...
-                     12000.0 14000.0 16000.0 18000.0 20000.0 25000.0 30000.0]/1000;
-                probetype=2;
-                tasMax=170;
-                
-                % Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 1e-6;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-        end
-        
-    otherwise
-        switch probename
-            case 'HVPS'
-                % For the HVPS
-                num_diodes =128;
-                diodesize = .150;
-                armdst=161.;
-                num_bins = 28;
-                kk=[200.0   400.0   600.0   800.0  1000.0  1200.0  1400.0  1600.0  1800.0  2200.0  2600.0 ...
-                     3000.0  3400.0  3800.0  4200.0  4600.0  5000.0  6000.0  7000.0  8000.0  9000.0 10000.0 ...
-                     12000.0 14000.0 16000.0 18000.0 20000.0 25000.0 30000.0]/1000;
-                %num_bins =128;
-                %kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                probetype=2;
-                tasMax=170; 
-				
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 4e-6;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-
-            case '2DS'
-                % For the HVPS
-                num_diodes =128;
-                diodesize = .010;
-                armdst=63.;
-                %num_bins = 28;
-                %kk=[200.0   400.0   600.0   800.0  1000.0  1200.0  1400.0  1600.0  1800.0  2200.0  2600.0 ...
-                %     3000.0  3400.0  3800.0  4200.0  4600.0  5000.0  6000.0  7000.0  8000.0  9000.0 10000.0 ...
-                %     12000.0 14000.0 16000.0 18000.0 20000.0 25000.0 30000.0]/1000/15;
-                num_bins =128;
-                %kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                kk=diodesize/2:diodesize:(num_bins+0.6)*diodesize;
-                probetype=2;
-                tasMax=170;  
-				
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 4e-6;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-
-            case 'CIP'
-                % For the CIP 
-                num_diodes =64;
-                diodesize = .025; %units of mm
-                armdst=100.;
-                %num_bins = 64;
-                %kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                num_bins=19;
-                kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000; %Array in microns - converted to mm
-                probetype=1;
-                tasMax=200; % Max airspeed that can be sampled without under-sampling (images would appear skewed)
-				
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 1e-5;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-
-            case 'PIP'
-                num_diodes =64;
-                diodesize = .1; %units of mm
-                armdst=260.;
-                num_bins = 64;
-%                 kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                kk=diodesize/2:diodesize:(num_bins+0.6)*diodesize;
-%                 num_bins=19;
-%                 kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-%                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]*4/1000;
-                probetype=1;
-                tasMax=200; 
-                
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 1e-5;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-
-
-            case '2DC'
-                % For the 2DC
-                num_diodes =32;
-                diodesize = .03; %.025;
-                armdst=61.;
-                %num_bins = 32;
-                %kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                num_bins=19;
-                kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000;
-                probetype=0;
-                tasMax=125;  
-				
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 4e-6;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-
-            case '2DP'
-                % For the 2DP
-                num_diodes =32;
-                diodesize = .200; %.025;
-                armdst=260.; %75.77; %61.;
-                %num_bins = 32;
-                %kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                num_bins=19;
-                kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]*8/1000;
-                probetype=0;
-				
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 4e-6;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-
-            case 'F2DC'
-                % For the 2DC
-                num_diodes =64;
-                diodesize = .025; %.025;
-                armdst=61.; %60; %
-                %num_bins = 32;
-                %kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
-                num_bins=19;
-                kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
-                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000;
-                probetype=0;
-				
-				% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
-				% **Values here may not be correct** 
-				% The interarrival threshold can be modifided to change second-by-second if desired
-                applyIntArrThresh = 0;
-					defaultIntArrThresh = 4e-6;
-				reaccptShatrs = 0;
-					reaccptD = 0.5; 
-					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
-                
-				intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
-        end
-end
-
-if applyIntArrThresh && ~reaccptShatrs
-	fprintf('Beginning sizeDist.m for %s %s - %s probe\n\t**Optional parameters active:\n\t- Shatter removal\n\n',projectname,ddate,probename);
-elseif applyIntArrThresh && reaccptShatrs
-	fprintf('Beginning sizeDist.m for %s %s - %s probe\n\t**Optional parameters active:\n\t- Shatter removal\n\t- Shatter reacceptance\n\n',...
-		projectname,ddate,probename);
-else
-	fprintf('Beginning sizeDist.m for %s %s - %s probe\n\n',projectname,ddate,probename);
-end
-
-res=diodesize*1000;
-binwidth=diff(kk);
-% SAmethod = 2;
-% for i=1:num_bins+1
-%     kk(i)=  (diodesize*i)^2*3.1415926/4; 
-% end
-
-
-%% Define Variables
-
-% Good particles (not rejected)
-particle_dist_minR  = zeros(length(tas),num_bins)*NaN;
-particle_dist_AreaR = zeros(length(tas),num_bins)*NaN;
-particle_aspectRatio = zeros(length(tas),num_bins)*NaN;
-particle_aspectRatio1 = zeros(length(tas),num_bins)*NaN;
-particle_areaRatio1 = zeros(length(tas),num_bins)*NaN;
-particle_area = zeros(length(tas),num_bins)*NaN;
-cip2_meanp = zeros(length(tas),num_bins)*NaN;
-cip2_iwc = zeros(length(tas),num_bins)*NaN;
-cip2_iwcbl = zeros(length(tas),num_bins)*NaN;
-cip2_vt = zeros(length(tas),num_bins)*NaN;
-cip2_pr = zeros(length(tas),num_bins)*NaN;
-cip2_partarea = zeros(length(tas),num_bins)*NaN;
-
-cip2_re = zeros(1,length(tas))*NaN;
-good_partpercent=zeros(length(tas),1);
-goodintpercent=zeros(length(tas),1);
-numGoodparticles=zeros(length(tas),1);
-one_sec_ar=zeros(length(tas),1);
-
-
-cip2_habitsd = zeros(length(tas),num_bins,10)*NaN;
-cip2_habitmsd = zeros(length(tas),num_bins,10)*NaN;
-area_dist2 = zeros(length(tas),num_bins,10)*NaN;
-
-rejectpercentbycriterion=zeros(length(tas),14);
-
-
-% Bad particles (rejected)
-bad_particle_dist_minR  = zeros(length(tas),num_bins)*NaN;
-bad_particle_dist_AreaR = zeros(length(tas),num_bins)*NaN;
-bad_particle_aspectRatio = zeros(length(tas),num_bins)*NaN;
-bad_particle_aspectRatio1 = zeros(length(tas),num_bins)*NaN;
-bad_particle_areaRatio1 = zeros(length(tas),num_bins)*NaN;
-bad_particle_area = zeros(length(tas),num_bins)*NaN;
-bad_cip2_meanp = zeros(length(tas),num_bins)*NaN;
-bad_cip2_iwc = zeros(length(tas),num_bins)*NaN;
-bad_cip2_iwcbl = zeros(length(tas),num_bins)*NaN;
-bad_cip2_vt = zeros(length(tas),num_bins)*NaN;
-bad_cip2_pr = zeros(length(tas),num_bins)*NaN;
-bad_cip2_partarea = zeros(length(tas),num_bins)*NaN;
-
-bad_cip2_re = zeros(1,length(tas))*NaN;
-badintpercent=zeros(length(tas),1);
-numBadparticles=zeros(length(tas),1);
-bad_one_sec_ar=zeros(length(tas),1);
-
-bad_cip2_habitsd = zeros(length(tas),num_bins,10)*NaN;
-bad_cip2_habitmsd = zeros(length(tas),num_bins,10)*NaN;
-bad_area_dist2 = zeros(length(tas),num_bins,10)*NaN;
-
-
-% particle_dist2 = zeros(length(tas),num_bins)*NaN; %Unused
-% time_interval1 = zeros(length(tas), 1); %Unused
-% cip2_ar = zeros(1,length(tas))*NaN; %Unused
-% throwoutpercent=zeros(length(tas),1); %Used in legacy interarrival time analysis
-% totalint=zeros(length(tas),1); %Used in legacy interarrival time analysis
-% intsum=zeros(length(tas),1); %Used in legacy interarrival time analysis
-
-area_bins = 0:.1:1.01;
-one_sec_times = tas_time;
-one_sec_dur = length(one_sec_times);
-total_one_sec_locs(1:one_sec_dur) = 0;
-start_time = floor(tas_time(1));
-end_time = ceil(tas_time(end));
-one_sec_tas(1:one_sec_dur) = 0;
-one_sec_tas_entire(1:one_sec_dur) = 0;
-deadtime(1:one_sec_dur) = 0;
-
-warning off all
-
-one_sec_times=[one_sec_times;one_sec_times(one_sec_dur)+1];
-time_interval2 = zeros(one_sec_dur,1);
-
-TotalPC1 = zeros(one_sec_dur,1)';
-TotalPC2 = zeros(one_sec_dur,1)';
-
-% Used for debugging of interarrival time analysis
-shatrReject_times = [];
-shatrReject_intArr = [];
-shatrReject_diam = [];
-
-rccptReject_times = [];
-rccptReject_intArr = [];
-rccptReject_diam = [];
-
-loopedTimes = [];
-loopedIntArr = [];
-loopedDiam = [];
-loopedAutoRej = [];
-
-%% Load particles for each second, and then process them
-% Only for large files cannot be processed at once
-[~, NumofPart] = netcdf.inqDim(f,0); % Check the number of particles
-
-if 1==probetype
-    image_time_hhmmssall = netcdf.getVar(f,netcdf.inqVarID(f,'particle_time'));
-elseif 2==probetype
-    image_time_hhmmssallbuffer = netcdf.getVar(f,netcdf.inqVarID(f,'Time'));
-%    image_time_hhmmssallbuffer(image_time_hhmmssallbuffer<10000 & image_time_hhmmssallbuffer>=0)=image_time_hhmmssallbuffer(image_time_hhmmssallbuffer<10000 & image_time_hhmmssallbuffer>=0)+240000;
-    alltimeinseconds = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'));
-    time_msec_all = netcdf.getVar(f,netcdf.inqVarID(f,'msec'),0,1);
-  
-    indexRollback=find(diff(alltimeinseconds)<-250)+1;
-    for i=1:length(indexRollback)
-        if mod(i,1000)==0
-            disp([num2str(i),' / ',num2str(length(indexRollback)),datestr(now)]) % Joe Finlon
-        end
-        alltimeinseconds(indexRollback(i):end)=alltimeinseconds(indexRollback(i):end)+(2^32-1)*(res/10^6/tasMax);
-    end
-   
-%    alltimeinsecondsstart=alltimeinseconds(indexBuffert);
-%    increaseAllinseconds= alltimeinseconds-alltimeinseconds(1);
-%    increaseAllinseconds(increaseAllinseconds<0)=increaseAllinseconds(increaseAllinseconds<0)+(2^32-1)*(res/10^6/170);
-%    image_time_hhmmssall = insec2hhmmss(floor(47069+time_msec_all(1)/1000.0+increaseAllinseconds*170/110));
-    image_time_hhmmssall = image_time_hhmmssallbuffer;
-else
-    image_time_hhmmssall = netcdf.getVar(f,netcdf.inqVarID(f,'Time'));
-end
-disp('Performing time correction.') % Joe Finlon
-% image_time_hhmmssall = netcdf.getVar(f,netcdf.inqVarID(f,'Time'));
-% image_time_hhmmssall(image_time_hhmmssall<50000 & image_time_hhmmssall>=0)=image_time_hhmmssall(image_time_hhmmssall<50000 & image_time_hhmmssall>=0)+120000;
-
-% Fix particle times if they span multiple days - Added by Joe Finlon -
-% 03/03/17
-image_time_hhmmssall(find(diff(image_time_hhmmssall)<0)+1:end)=...
-    image_time_hhmmssall(find(diff(image_time_hhmmssall)<0)+1:end) + 240000;
-
-% Find all indices (true/1) with a unique time in hhmmss - in other words, we're getting the particle index where each new
-% one-second period starts
-startindex=[true;(diff(hhmmss2insec(image_time_hhmmssall))>0)]; % & diff(hhmmss2insec(image_time_hhmmssall))<5)]; % Simplified (tested/changed by DS)
-
-% startindex=int8(image_time_hhmmssall*0);
-% for i=1:length(timehhmmss)
-%    indexofFirstTime =  find(image_time_hhmmssall==timehhmmss(i),1);
-%    if ( ~isempty(indexofFirstTime) )
-%        startindex(indexofFirstTime)=1;
-%    end
-%    disp([i,length(timehhmmss)]);
-% end
-
-
-% Get the start time for each new one-second period
-starttime=image_time_hhmmssall(startindex); % Simplified (tested/changed by DS)
-
-
-% Find all instances where startindex is true (where image_time_hhmmssall changes by more than 0) and shift indices back by one to
-% facilitate proper particle counts for each one-second period
-start_all=find(startindex)-1; % Simplified (tested/changed by DS)
-
-% Sort the particle one-second time array in the event it is out of order and redefine the start_all variable as needed
-[starttime,newindexofsort]=sort(starttime);
-start_all=start_all(newindexofsort);
-
-%% Remove times when there is no tas data available
-% nNoTAS=0;
-% for i=1:length(starttime)
-%     if isempty(timehhmmss(timehhmmss == starttime(i)))
-%         starttime(i)=500000;
-%         nNoTAS=nNoTAS+1;
-%     end
-%     
-%     if i>5 & i<length(starttime)-5 & hhmmss2insec(starttime(i))>mean(hhmmss2insec(starttime(i-5:i+5)))+5
-%         starttime(i)=500000;
-%     end
-% end
-% nNoTAS
-% start_all = start_all(starttime<500000);
-% count_all = count_all(starttime<500000);
-% starttime = starttime(starttime<500000);
-
-%% Remove any duplicate times and determine how many particles are present in each one-second period
-fprintf('Number of duplicate times = %d\n\n',(length(starttime)-length(unique(starttime))));
-
-[starttime, ia, ~] = unique(starttime,'first');
-start_all = start_all(ia);
-count_all= [diff(start_all); NumofPart-start_all(end)];
-count_all(count_all<0)=1;
-
-%% Remove times when there are less than 10 particles in one second
-% starttime = starttime(count_all>10);
-% start_all = start_all(count_all>10);
-% count_all = count_all(count_all>10);
-
-%if (int32(timehhmmss(1))>int32(starttime(2)))
-%    error('Watch Out for less TAS time from begining!')
-%end
-
-%% Main loop over the length of the true air speed variable (1-sec resolution)
-jjj=1;
-eofFlag=0; % end of the particle data flag - Added by Joe Finlon - 03/03/17
-
-sumIntArrGT1 = 0;
-intArrGT1 = [];
-
-% nThrow11=0; % Used in legacy interarrival time analysis
-% maxRecNum=1; % Used in legacy interarrival time analysis
-
-fprintf('Beginning size distribution calculations and sorting %s\n\n',datestr(now));
-
-for i=1:length(tas) 
+	
+	iCreateBad = 0; % Calculate PSDs and other quantities for rejected particles alone (good particles still calculated separately)
+	iCreateAspectRatio = 1;
+	iSaveIntArrSV = 1; % Default not to save inter-arrival and sample volume information
     
-%     if (int32(timehhmmss(i))>=int32(starttime(jjj)))
-    if (eofFlag==0 && int32(timehhmmss(i))>=int32(starttime(jjj))) % Modified by Joe Finlon - 03/03/17
+    %% Interarrival threshold file specification
+    % Can be implemented if a time-dependent threshold is required - add 'varargin' to arguments in function header above
+
+    if length(varargin) == 1
+        iaThreshFile = varargin{1};
+    elseif length(varargin) == 2
+        iaThreshFile = varargin{1};
+        prmsF = varargin{2};
+    elseif length(varargin) > 2
+        display('Too many optional arguments supplied - ignoring...')
+        iaThreshFile = varargin{1};
+        prmsF = varargin{2};
+    elseif length(varargin) == 0
+        iaThreshFile = 'NONE';
+        prmsF = 'NONE';
+    end
+	
+	% Fix flight times if they span multiple days - Added by Joe Finlon -
+    % 03/03/17
+    timehhmmss(find(diff(timehhmmss)<0)+1:end)=...
+        timehhmmss(find(diff(timehhmmss)<0)+1:end) + 240000;
+	
+	% tas_char = num2str(timehhmmss); %Unused
+	tas_time = floor(timehhmmss/10000)*3600+floor(mod(timehhmmss,10000)/100)*60+floor(mod(timehhmmss,100));
+	% averaging_time = 1;
+	
+	
+	%% Project-, probe-, and date-specific information
+	switch projectname
+		case 'PECAN'
+		    if ~strcmp(prmsF,'NONE')
+                prmsF = netcdf.open(prmsF,'nowrite');
+            else
+                error('PECAN size distribution processing requires an input parameters file. Please specify in second optional argument position');
+            end
+			switch probename
+				case 'CIP'
+					num_diodes =64;
+					diodesize = 0.025; % units of mm
+					armdst=100.;
+% 					num_bins = 64;
+% 					kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					%                 num_bins=19;
+					%                 kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+					%                     700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000; %Array in microns - converted to mm
+% 					kk=[25.0	50.0	75.0	100.0	125.0	150.0	175.0	200.0	225.0	250.0	275.0...
+% 						300.0	325.0	350.0	375.0	400.0	425.0	450.0	475.0	500.0	550.0	600.0...
+% 						650.0	700.0	750.0	800.0	850.0	900.0	1000.0	1100.0	1250.0	1400.0	1600.0	1800.0	2000.0]/1000; %Array in microns - converted to mm
+					kk=[50.0 100.0	150.0	200.0	250.0	300.0	350.0	400.0	450.0	500.0	600.0	650.0	700.0...
+						750.0	800.0	850.0	900.0	950.0	1000.0	1100.0	1250.0	1400.0	1600.0 1800.0 2000.0]/1000;
+					%kk=0.0125:0.025:1.6125; %Bob Black Bins (bin mids at 25, 50, 75, ..., 1600 um)
+					num_bins = length(kk)-1;
+					probetype=1;
+					tasMax=200; % Max airspeed that can be sampled without under-sampling (images would appear skewed)
+					
+					
+					applyIntArrThresh = 1;
+					defaultIntArrThresh = 1e-5;
+					reaccptShatrs = 1;
+					reaccptD = 0.5; % Diammeter (in mm) to reaccept if initially flagged as shattered
+					reaccptMaxIA = 2.5e-7;	% Max interarrival time in seconds a particle can have to be reaccepted if
+					% size criteria are met. Possible definition of this is the time of one slice, so in
+					% this case, with an airspeed of ~100 m/s and a slice of 25 um, this would be 2.5e-7.
+					
+					
+					% Get start and end times (in seconds) of spirals; interarrival time thresholds for each spiral
+					startT = netcdf.getVar(prmsF,netcdf.inqVarID(prmsF,'startT'));
+					endT = netcdf.getVar(prmsF,netcdf.inqVarID(prmsF,'endT'));
+					intar_threshold_spirals = netcdf.getVar(prmsF,netcdf.inqVarID(prmsF,'CIP_intArvThrsh'));
+					
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					for ix = 1:length(tas_time)
+						for iz = 1:length(startT)
+							if (tas_time(ix) >= startT(iz) && tas_time(ix) < endT(iz))
+								intar_threshold(ix) = intar_threshold_spirals(iz);
+							end
+						end
+					end
+					
+				case 'PIP'
+					num_diodes =64;
+					diodesize = 0.1; %units of mm
+					armdst=260.;
+% 					num_bins = 64;
+% 					kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					%                 num_bins=19;
+					%                 kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+					%                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]*4/1000;
+% 					kk=[100.0	250.0	400.0	550.0	700.0	850.0	1000.0	1200.0	1400.0	1600.0	1800.0	2000.0...
+% 						2200.0	2400.0	2600.0	2800.0	3000.0	3200.0	3400.0	3600.0	3800.0	4000.0	4200.0	4400.0...
+% 						4600.0	4800.0	5000.0	5200.0	5500.0	5800.0	6100.0	6400.0	6700.0	7000.0	7300.0]/1000;
+                    kk=[100.0	150.0	200.0	250.0	300.0	350.0	400.0	450.0	500.0	600.0	650.0	700.0...
+						750.0	800.0	850.0	900.0	950.0	1000.0	1100.0	1250.0	1400.0	1600.0	1800.0	2000.0...
+ 						2300.0	2600.0	2900.0	3200.0	3600.0	4000.0	4500.0	5000.0	5500.0	6000.0	7300.0]/1000;
+					%kk=0.05:0.1:6.45; %Bob Black Bins (bin mids at 100, 200, 300, ..., 6400 um)
+					num_bins = length(kk)-1;
+					probetype=1;
+					tasMax=200;
+					
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 1e-5;
+					reaccptShatrs = 1;
+					reaccptD = 0.5; % Diammeter (in mm) to reaccept if initially flagged as shattered
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					% Get start and end times (in seconds) of spirals; interarrival time thresholds for each spiral
+					startT = netcdf.getVar(prmsF,netcdf.inqVarID(prmsF,'startT'));
+					endT = netcdf.getVar(prmsF,netcdf.inqVarID(prmsF,'endT'));
+					intar_threshold_spirals = netcdf.getVar(prmsF,netcdf.inqVarID(prmsF,'PIP_intArvThrsh'));
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					for ix = 1:length(tas_time)
+						for iz = 1:length(startT)
+							if (tas_time(ix) >= startT(iz) && tas_time(ix) < endT(iz))
+								intar_threshold(ix) = intar_threshold_spirals(iz);
+							end
+						end
+					end
+			end
+		
+		case 'GPM'
+            switch probename
+                case '2DS'
+                    num_diodes =128;
+                    diodesize = .010;
+                    armdst=63.;
+                    num_bins =22;
+                    kk=[40.0    60.0    80.0   100.0   125.0   150.0   200.0   250.0   300.0   350.0   400.0 ...
+                        475.0   550.0   625.0   700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000;
+                    probetype=2;
+                    tasMax=170;
+                
+                    % Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+                    % **Values here may not be correct** 
+                    % The interarrival threshold can be modifided to change second-by-second if desired
+                    applyIntArrThresh = 1;
+                        defaultIntArrThresh = 1e-6;
+                    reaccptShatrs = 1;
+                        reaccptD = 0.5;
+                        %reaccptMaxIA = 1e-7; % (Slice size [m])/(avg. airspeed [m/s])
+                        reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+                    
+                case 'CIP'
+                    num_diodes =64;
+                    diodesize = 0.025; % units of mm
+                    armdst=100.;
+                    num_bins=19;
+                    kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+                        700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000; %Array in microns - converted to mm
+                    probetype=1;
+                    tasMax=200; % Max airspeed that can be sampled without under-sampling (images would appear skewed)
+                
+                    applyIntArrThresh = 1;
+                        defaultIntArrThresh = 1e-6;
+                    reaccptShatrs = 1;
+                        reaccptD = 0.5; % Diammeter (in mm) to reaccept if initially flagged as shattered
+                        reaccptMaxIA = 2.5e-7;	% Max interarrival time in seconds a particle can have to be reaccepted if 
+                                                % size criteria are met. Possible definition of this is the time of one slice, so in
+                                                % this case, with an airspeed of ~100 m/s and a slice of 25 um, this would be 2.5e-7.
+                                               
+                case 'HVPS'
+                    % For the HVPS
+                    num_diodes =128;
+                    diodesize = .150;
+                    armdst=161.;
+                    num_bins = 28;
+                    kk=[200.0   400.0   600.0   800.0  1000.0  1200.0  1400.0  1600.0  1800.0  2200.0  2600.0 ...
+                         3000.0  3400.0  3800.0  4200.0  4600.0  5000.0  6000.0  7000.0  8000.0  9000.0 10000.0 ...
+                         12000.0 14000.0 16000.0 18000.0 20000.0 25000.0 30000.0]/1000;
+                    probetype=2;
+                    tasMax=170;
+                
+                    % Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+                    % **Values here may not be correct** 
+                    % The interarrival threshold can be modifided to change second-by-second if desired
+                    applyIntArrThresh = 0;
+                        defaultIntArrThresh = 1e-6;
+                    reaccptShatrs = 0;
+                        reaccptD = 0.5; 
+                        reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+                
+            end
+			
+		otherwise
+			switch probename
+				case 'HVPS'
+					% For the HVPS
+					num_diodes =128;
+					diodesize = .150;
+					armdst=161.;
+					num_bins = 28;
+					kk=[200.0   400.0   600.0   800.0  1000.0  1200.0  1400.0  1600.0  1800.0  2200.0  2600.0 ...
+						3000.0  3400.0  3800.0  4200.0  4600.0  5000.0  6000.0  7000.0  8000.0  9000.0 10000.0 ...
+						12000.0 14000.0 16000.0 18000.0 20000.0 25000.0 30000.0]/1000;
+					%num_bins =128;
+					%kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					probetype=2;
+					tasMax=170;
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 4e-6;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					
+				case '2DS'
+					% For the HVPS
+					num_diodes =128;
+					diodesize = .010;
+					armdst=63.;
+					%num_bins = 28;
+					%kk=[200.0   400.0   600.0   800.0  1000.0  1200.0  1400.0  1600.0  1800.0  2200.0  2600.0 ...
+					%     3000.0  3400.0  3800.0  4200.0  4600.0  5000.0  6000.0  7000.0  8000.0  9000.0 10000.0 ...
+					%     12000.0 14000.0 16000.0 18000.0 20000.0 25000.0 30000.0]/1000/15;
+					num_bins =128;
+					%kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					kk=diodesize/2:diodesize:(num_bins+0.6)*diodesize;
+					probetype=2;
+					tasMax=170;
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 4e-6;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					
+				case 'CIP'
+					% For the CIP
+					num_diodes =64;
+					diodesize = .025; %units of mm
+					armdst=100.;
+					%num_bins = 64;
+					%kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					num_bins=19;
+					kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+						700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000; %Array in microns - converted to mm
+					probetype=1;
+					tasMax=200; % Max airspeed that can be sampled without under-sampling (images would appear skewed)
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 1e-5;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					
+				case 'PIP'
+					num_diodes =64;
+					diodesize = .1; %units of mm
+					armdst=260.;
+					num_bins = 64;
+					%                 kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					kk=diodesize/2:diodesize:(num_bins+0.6)*diodesize;
+					%                 num_bins=19;
+					%                 kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+					%                    700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]*4/1000;
+					probetype=1;
+					tasMax=200;
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 1e-5;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					
+					
+				case '2DC'
+					% For the 2DC
+					num_diodes =32;
+					diodesize = .03; %.025;
+					armdst=61.;
+					%num_bins = 32;
+					%kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					num_bins=19;
+					kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+						700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000;
+					probetype=0;
+					tasMax=125;
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 4e-6;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					
+				case '2DP'
+					% For the 2DP
+					num_diodes =32;
+					diodesize = .200; %.025;
+					armdst=260.; %75.77; %61.;
+					%num_bins = 32;
+					%kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					num_bins=19;
+					kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+						700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]*8/1000;
+					probetype=0;
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 4e-6;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+					
+				case 'F2DC'
+					% For the 2DC
+					num_diodes =64;
+					diodesize = .025; %.025;
+					armdst=61.; %60; %
+					%num_bins = 32;
+					%kk=diodesize/2:diodesize:(num_bins+0.5)*diodesize;
+					num_bins=19;
+					kk=[50.0   100.0   150.0   200.0   250.0   300.0   350.0   400.0   475.0   550.0   625.0 ...
+						700.0   800.0   900.0  1000.0  1200.0  1400.0  1600.0  1800.0  2000.0]/1000;
+					probetype=0;
+					
+					% Interarrival threshold and reaccept max interarrival time are often flight-/instrument-specific
+					% **Values here may not be correct**
+					% The interarrival threshold can be modifided to change second-by-second if desired
+					applyIntArrThresh = 0;
+					defaultIntArrThresh = 4e-6;
+					reaccptShatrs = 0;
+					reaccptD = 0.5;
+					reaccptMaxIA = 1e-6; % (Slice size [m])/(avg. airspeed [m/s])
+					
+					intar_threshold = ones(size(tas_time))*defaultIntArrThresh;
+			end
+	end
+	
+	%% Define input and output files and initialize time variable
+	f = netcdf.open(infile,'nowrite');
+	if iCreateBad
+		mainf = netcdf.create([outfile(1:end-3) 'wRejSD.cdf'], 'clobber');
+	else
+		mainf = netcdf.create(outfile, 'clobber');
+	end
+	
+	
+	if applyIntArrThresh && ~reaccptShatrs
+		fprintf('Beginning sizeDist_Paris.m for %s %s - %s probe\n\t**Optional parameters active:\n\t- Shatter removal\n\n',projectname,ddate,probename);
+	elseif applyIntArrThresh && reaccptShatrs
+		fprintf('Beginning sizeDist_Paris.m for %s %s - %s probe\n\t**Optional parameters active:\n\t- Shatter removal\n\t- Shatter reacceptance\n\n',...
+			projectname,ddate,probename);
+	else
+		fprintf('Beginning sizeDist_Paris.m for %s %s - %s probe\n\n',projectname,ddate,probename);
+	end
+	
+	res=diodesize*1000;
+	binwidth=diff(kk);
+	% SAmethod = 2;
+	% for i=1:num_bins+1
+	%     kk(i)=  (diodesize*i)^2*3.1415926/4;
+	% end
+	
+	
+	%% Define Variables
+	
+	% Good particles (not rejected)
+	particle_dist_minR  = zeros(length(tas),num_bins)*NaN;
+	particle_dist_AreaR = zeros(length(tas),num_bins)*NaN;
+	particle_aspectRatio = zeros(length(tas),num_bins)*NaN;
+	particle_aspectRatio1 = zeros(length(tas),num_bins)*NaN;
+	particle_areaRatio1 = zeros(length(tas),num_bins)*NaN;
+	particle_area = zeros(length(tas),num_bins)*NaN;
+	cip2_meanp = zeros(length(tas),num_bins)*NaN;
+	cip2_iwc = zeros(length(tas),num_bins)*NaN;
+	cip2_lwc = zeros(length(tas),num_bins)*NaN;
+	cip2_iwcbl = zeros(length(tas),num_bins)*NaN;
+	cip2_vt_ice = zeros(length(tas),num_bins)*NaN;
+	cip2_vt_lw = zeros(length(tas),num_bins)*NaN;
+	cip2_pr_ice = zeros(length(tas),num_bins)*NaN;
+	cip2_pr_lw = zeros(length(tas),num_bins)*NaN;
+	cip2_partarea = zeros(length(tas),num_bins)*NaN;
+	
+	cip2_re = zeros(1,length(tas))*NaN;
+	good_partpercent=zeros(length(tas),1);
+	goodintpercent=zeros(length(tas),1);
+	numGoodparticles=zeros(length(tas),1);
+	one_sec_ar=zeros(length(tas),1);
+	
+	
+	cip2_habitsd = zeros(length(tas),num_bins,10)*NaN;
+	cip2_habitmsd = zeros(length(tas),num_bins,10)*NaN;
+	area_dist2 = zeros(length(tas),num_bins,10)*NaN;
+	
+	rejectpercentbycriterion=zeros(length(tas),14);
+	
+	
+	% Bad particles (rejected)
+	if iCreateBad
+		bad_particle_dist_minR  = zeros(length(tas),num_bins)*NaN;
+		bad_particle_dist_AreaR = zeros(length(tas),num_bins)*NaN;
+		bad_particle_aspectRatio = zeros(length(tas),num_bins)*NaN;
+		bad_particle_aspectRatio1 = zeros(length(tas),num_bins)*NaN;
+		bad_particle_areaRatio1 = zeros(length(tas),num_bins)*NaN;
+		bad_particle_area = zeros(length(tas),num_bins)*NaN;
+		bad_cip2_meanp = zeros(length(tas),num_bins)*NaN;
+		bad_cip2_iwc = zeros(length(tas),num_bins)*NaN;
+		bad_cip2_iwcbl = zeros(length(tas),num_bins)*NaN;
+		bad_cip2_vt = zeros(length(tas),num_bins)*NaN;
+		bad_cip2_pr = zeros(length(tas),num_bins)*NaN;
+		bad_cip2_partarea = zeros(length(tas),num_bins)*NaN;
+		
+		bad_cip2_re = zeros(1,length(tas))*NaN;
+		badintpercent=zeros(length(tas),1);
+		numBadparticles=zeros(length(tas),1);
+		bad_one_sec_ar=zeros(length(tas),1);
+		
+		bad_cip2_habitsd = zeros(length(tas),num_bins,10)*NaN;
+		bad_cip2_habitmsd = zeros(length(tas),num_bins,10)*NaN;
+		bad_area_dist2 = zeros(length(tas),num_bins,10)*NaN;
+	end
+	
+	% particle_dist2 = zeros(length(tas),num_bins)*NaN; %Unused
+	% time_interval1 = zeros(length(tas), 1); %Unused
+	% cip2_ar = zeros(1,length(tas))*NaN; %Unused
+	% throwoutpercent=zeros(length(tas),1); %Used in legacy interarrival time analysis
+	% totalint=zeros(length(tas),1); %Used in legacy interarrival time analysis
+	% intsum=zeros(length(tas),1); %Used in legacy interarrival time analysis
+	
+	area_bins = 0:.1:1.01;
+	one_sec_times = tas_time;
+	one_sec_dur = length(one_sec_times);
+	total_one_sec_locs(1:one_sec_dur) = 0;
+	start_time = floor(tas_time(1));
+	end_time = ceil(tas_time(end));
+	one_sec_tas(1:one_sec_dur) = 0;
+	one_sec_tas_entire(1:one_sec_dur) = 0;
+	deadtime(1:one_sec_dur) = 0;
+	
+	warning off all
+	
+	one_sec_times=[one_sec_times;one_sec_times(one_sec_dur)+1];
+	time_interval2 = zeros(one_sec_dur,1);
+	
+	TotalPC1 = zeros(one_sec_dur,1)';
+	TotalPC2 = zeros(one_sec_dur,1)';
+	
+	% Used for debugging of interarrival time analysis
+	shatrReject_times = [];
+	shatrReject_intArr = [];
+	shatrReject_diam = [];
+	
+	rccptReject_times = [];
+	rccptReject_intArr = [];
+	rccptReject_diam = [];
+	
+	loopedTimes = [];
+	loopedIntArr = [];
+	loopedDiam = [];
+	loopedAutoRej = [];
+	
+	%% Load particles for each second, and then process them
+	% Only for large files cannot be processed at once
+	[~, NumofPart] = netcdf.inqDim(f,0); % Check the number of particles
+	
+	if 1==probetype
+		image_time_hhmmssall = netcdf.getVar(f,netcdf.inqVarID(f,'particle_time'));
+	elseif 2==probetype
+		image_time_hhmmssallbuffer = netcdf.getVar(f,netcdf.inqVarID(f,'Time'));
+		%    image_time_hhmmssallbuffer(image_time_hhmmssallbuffer<10000 & image_time_hhmmssallbuffer>=0)=image_time_hhmmssallbuffer(image_time_hhmmssallbuffer<10000 & image_time_hhmmssallbuffer>=0)+240000;
+		alltimeinseconds = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'));
+		time_msec_all = netcdf.getVar(f,netcdf.inqVarID(f,'msec'),0,1);
+		
+		indexRollback=find(diff(alltimeinseconds)<-250)+1;
+		
+		for i=1:length(indexRollback)
+			if mod(i,1000)==0
+                disp([num2str(i),' / ',num2str(length(indexRollback)),datestr(now)]) % Joe Finlon
+            end
+			alltimeinseconds(indexRollback(i):end)=alltimeinseconds(indexRollback(i):end)+(2^32-1)*(res/10^6/tasMax);
+		end
+		
+		%    alltimeinsecondsstart=alltimeinseconds(indexBuffert);
+		%    increaseAllinseconds= alltimeinseconds-alltimeinseconds(1);
+		%    increaseAllinseconds(increaseAllinseconds<0)=increaseAllinseconds(increaseAllinseconds<0)+(2^32-1)*(res/10^6/170);
+		%    image_time_hhmmssall = insec2hhmmss(floor(47069+time_msec_all(1)/1000.0+increaseAllinseconds*170/110));
+		image_time_hhmmssall = image_time_hhmmssallbuffer;
+	else
+		image_time_hhmmssall = netcdf.getVar(f,netcdf.inqVarID(f,'Time'));
+	end
+	
+	% image_time_hhmmssall = netcdf.getVar(f,netcdf.inqVarID(f,'Time'));
+	% image_time_hhmmssall(image_time_hhmmssall<50000 & image_time_hhmmssall>=0)=image_time_hhmmssall(image_time_hhmmssall<50000 & image_time_hhmmssall>=0)+120000;
+	
+	% Fix particle times if they span multiple days - Added by Joe Finlon -
+    % 03/03/17
+    image_time_hhmmssall(find(diff(image_time_hhmmssall)<0)+1:end)=...
+        image_time_hhmmssall(find(diff(image_time_hhmmssall)<0)+1:end) + 240000;
+	
+	% Find all indices (true/1) with a unique time in hhmmss - in other words, we're getting the particle index where each new
+	% one-second period starts
+	startindex=[true;(diff(hhmmss2insec(image_time_hhmmssall))>0)]; % & diff(hhmmss2insec(image_time_hhmmssall))<5)]; % Simplified (tested/changed by DS)
+	
+	% startindex=int8(image_time_hhmmssall*0);
+	% for i=1:length(timehhmmss)
+	%    indexofFirstTime =  find(image_time_hhmmssall==timehhmmss(i),1);
+	%    if ( ~isempty(indexofFirstTime) )
+	%        startindex(indexofFirstTime)=1;
+	%    end
+	%    disp([i,length(timehhmmss)]);
+	% end
+	
+	
+	% Get the start time for each new one-second period
+	starttime=image_time_hhmmssall(startindex); % Simplified (tested/changed by DS)
+	
+	
+	% Find all instances where startindex is true (where image_time_hhmmssall changes by more than 0) and shift indices back by one to
+	% facilitate proper particle counts for each one-second period
+	start_all=find(startindex)-1; % Simplified (tested/changed by DS)
+	
+	% Sort the particle one-second time array in the event it is out of order and redefine the start_all variable as needed
+	[starttime,newindexofsort]=sort(starttime);
+	start_all=start_all(newindexofsort);
+	
+	
+	%% Remove times when there is no tas data available
+	% nNoTAS=0;
+	% for i=1:length(starttime)
+	%     if isempty(timehhmmss(timehhmmss == starttime(i)))
+	%         starttime(i)=500000;
+	%         nNoTAS=nNoTAS+1;
+	%     end
+	%
+	%     if i>5 & i<length(starttime)-5 & hhmmss2insec(starttime(i))>mean(hhmmss2insec(starttime(i-5:i+5)))+5
+	%         starttime(i)=500000;
+	%     end
+	% end
+	% nNoTAS
+	% start_all = start_all(starttime<500000);
+	% count_all = count_all(starttime<500000);
+	% starttime = starttime(starttime<500000);
+	
+	%% Remove any duplicate times and determine how many particles are present in each one-second period
+	fprintf('Number of duplicate times = %d\n\n',(length(starttime)-length(unique(starttime))));
+	
+	[starttime, ia, ~] = unique(starttime,'first');
+	start_all = start_all(ia);
+	count_all= [diff(start_all); NumofPart-start_all(end)];
+	count_all(count_all<0)=1;
+	
+	%% Remove times when there are less than 10 particles in one second
+	% starttime = starttime(count_all>10);
+	% start_all = start_all(count_all>10);
+	% count_all = count_all(count_all>10);
+	
+	%if (int32(timehhmmss(1))>int32(starttime(2)))
+	%    error('Watch Out for less TAS time from begining!')
+	%end
+	
+	%% Main loop over the length of the true air speed variable (1-sec resolution)
+	jjj=1;
+	eofFlag=0; % end of the particle data flag - Added by Joe Finlon - 03/03/17
+	
+	sumIntArrGT1 = 0;
+	intArrGT1 = [];
+	
+	% nThrow11=0; % Used in legacy interarrival time analysis
+	% maxRecNum=1; % Used in legacy interarrival time analysis
+	
+	fprintf('Beginning size distribution calculations and sorting %s\n\n',datestr(now));
+	
+	for i=1:length(tas) 
+    
+    %     if (int32(timehhmmss(i))>=int32(starttime(jjj)))
+        if (eofFlag==0 && int32(timehhmmss(i))>=int32(starttime(jjj))) % Modified by Joe Finlon - 03/03/17
         
-        % Attempt to sync TAS file time (timehhmmss) with particle time
-%         if (int32(timehhmmss(i))>int32(starttime(jjj))) %% Deprecated
-%         (Joe Finlon - 03/03/17)
-        while (int32(timehhmmss(i))>int32(starttime(jjj))) % Added by Joe Finlon - 03/03/17
-            jjj=jjj+1;
+            % Attempt to sync TAS file time (timehhmmss) with particle time
+    %         if (int32(timehhmmss(i))>int32(starttime(jjj))) %% Deprecated
+    %         (Joe Finlon - 03/03/17)
+            while (int32(timehhmmss(i))>int32(starttime(jjj))) % Added by Joe Finlon - 03/03/17
+                jjj=jjj+1;
+                if (jjj==length(start_all)) % we've reached the end of the particle data - Added by Joe Finlon - 03/03/17
+                    eofFlag = 1;
+                end
+            
+    %             if (jjj>length(start_all))
+    %                 break;
+    %             end
+            end
+        
             if (jjj==length(start_all)) % we've reached the end of the particle data - Added by Joe Finlon - 03/03/17
                 eofFlag = 1;
             end
-            
-%             if (jjj>length(start_all))
-%                 break;
-%             end
-        end
-        
-        if (jjj==length(start_all)) % we've reached the end of the particle data - Added by Joe Finlon - 03/03/17
-            eofFlag = 1;
-        end
-        
-        start=start_all(jjj);
-        count=count_all(jjj);
-        jjj=min(jjj+1,length(start_all));
-        
-        % Load autoanalysis parameters. Start at beginning (start) of some one-second period and load the values for every
-        % particle in that period (count)
-        msec = netcdf.getVar(f,netcdf.inqVarID(f,'particle_millisec'),start,count);
-        microsec = netcdf.getVar(f,netcdf.inqVarID(f,'particle_microsec'),start,count);
-        auto_reject = netcdf.getVar(f,netcdf.inqVarID(f,'image_auto_reject'),start,count);
-        im_width = netcdf.getVar(f,netcdf.inqVarID(f,'image_width'),start,count);
-        im_length = netcdf.getVar(f,netcdf.inqVarID(f,'image_length'),start,count);
-        area = netcdf.getVar(f,netcdf.inqVarID(f,'image_area'),start,count);
-        perimeter = netcdf.getVar(f,netcdf.inqVarID(f,'image_perimeter'),start,count);
-%         rec_nums = netcdf.getVar(f,netcdf.inqVarID(f,'parent_rec_num'),start,count); %Used in legacy interarrival time analysis
-%         top_edges = netcdf.getVar(f,netcdf.inqVarID(f,'image_max_top_edge_touching'),start,count); %Unused
-%         bot_edges = netcdf.getVar(f,netcdf.inqVarID(f,'image_max_bottom_edge_touching'),start,count); %Unused
-%         longest_y = netcdf.getVar(f,netcdf.inqVarID(f,'image_longest_y'),start,count); %Unused
-        size_factor = netcdf.getVar(f,netcdf.inqVarID(f,'size_factor'),start,count);
-        habit1 = netcdf.getVar(f,netcdf.inqVarID(f,'holroyd_habit'),start,count);
-        centerin = netcdf.getVar(f,netcdf.inqVarID(f,'image_center_in'),start,count);
-        entirein = netcdf.getVar(f,netcdf.inqVarID(f,'image_touching_edge'),start,count);
-        
-        particle_diameter_AreaR = netcdf.getVar(f,netcdf.inqVarID(f,'image_diam_AreaR'),start,count);
-        particle_diameter_AreaR = particle_diameter_AreaR * diodesize;
-
-        Time_in_seconds = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start,count);
-%         SliceCount = netcdf.getVar(f,netcdf.inqVarID(f,'SliceCount'),start,count); %Unused
-        if probetype~=0 % skip reading variables if 2DC/2DP - Joe Finlon - 06/26/17
-            DMT_DOF_SPEC_OVERLOAD = netcdf.getVar(f,netcdf.inqVarID(f,'DMT_DOF_SPEC_OVERLOAD'),start,count);
-            Particle_count = netcdf.getVar(f,netcdf.inqVarID(f,'Particle_number_all'),start,count);
-            TotalPC1(i)=length(Particle_count);        
-            TotalPC2(i)=Particle_count(end)-Particle_count(1);
-        end
-        
-        if 1==probetype
-            auto_reject(DMT_DOF_SPEC_OVERLOAD~=0)='D';
-        end
-        
-        if iCreateAspectRatio == 1
-            aspectRatio = netcdf.getVar(f,netcdf.inqVarID(f,'image_RectangleW'),start,count)./netcdf.getVar(f,netcdf.inqVarID(f,'image_RectangleL'),start,count);
-            aspectRatio1 = netcdf.getVar(f,netcdf.inqVarID(f,'image_EllipseW'),start,count)./netcdf.getVar(f,netcdf.inqVarID(f,'image_EllipseL'),start,count);
-        end
-
-        if 0==probetype
-            int_arr=Time_in_seconds;
-		else
-			if start-1 <= 0
-				int_arr = [0;diff(Time_in_seconds)];
-				int_arr2 = []; %Won't bother reaccepting particles at the beginning or end of dataset				
+			
+			start=start_all(jjj);
+			count=count_all(jjj);
+			jjj=min(jjj+1,length(start_all));
+			
+			% Load autoanalysis parameters. Start at beginning (start) of some one-second period and load the values for every
+			% particle in that period (count)
+			msec = netcdf.getVar(f,netcdf.inqVarID(f,'particle_millisec'),start,count);
+			microsec = netcdf.getVar(f,netcdf.inqVarID(f,'particle_microsec'),start,count);
+			auto_reject = netcdf.getVar(f,netcdf.inqVarID(f,'image_auto_reject'),start,count);
+			im_width = netcdf.getVar(f,netcdf.inqVarID(f,'image_width'),start,count);
+			im_length = netcdf.getVar(f,netcdf.inqVarID(f,'image_length'),start,count);
+			area = netcdf.getVar(f,netcdf.inqVarID(f,'image_area'),start,count);
+			perimeter = netcdf.getVar(f,netcdf.inqVarID(f,'image_perimeter'),start,count);
+			%         rec_nums = netcdf.getVar(f,netcdf.inqVarID(f,'parent_rec_num'),start,count); %Used in legacy interarrival time analysis
+			%         top_edges = netcdf.getVar(f,netcdf.inqVarID(f,'image_max_top_edge_touching'),start,count); %Unused
+			%         bot_edges = netcdf.getVar(f,netcdf.inqVarID(f,'image_max_bottom_edge_touching'),start,count); %Unused
+			%         longest_y = netcdf.getVar(f,netcdf.inqVarID(f,'image_longest_y'),start,count); %Unused
+			size_factor = netcdf.getVar(f,netcdf.inqVarID(f,'size_factor'),start,count);
+			habit1 = netcdf.getVar(f,netcdf.inqVarID(f,'holroyd_habit'),start,count);
+			centerin = netcdf.getVar(f,netcdf.inqVarID(f,'image_center_in'),start,count);
+			entirein = netcdf.getVar(f,netcdf.inqVarID(f,'image_touching_edge'),start,count);
+			
+			particle_diameter_AreaR = netcdf.getVar(f,netcdf.inqVarID(f,'image_diam_AreaR'),start,count);
+			particle_diameter_AreaR = particle_diameter_AreaR * diodesize;
+			
+			Time_in_seconds = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start,count);
+			%         SliceCount = netcdf.getVar(f,netcdf.inqVarID(f,'SliceCount'),start,count); %Unused
+			if probetype~=0 % skip reading variables if 2DC/2DP - Joe Finlon - 06/26/17
+                DMT_DOF_SPEC_OVERLOAD = netcdf.getVar(f,netcdf.inqVarID(f,'DMT_DOF_SPEC_OVERLOAD'),start,count);
+                Particle_count = netcdf.getVar(f,netcdf.inqVarID(f,'Particle_number_all'),start,count);
+                TotalPC1(i)=length(Particle_count);        
+                TotalPC2(i)=Particle_count(end)-Particle_count(1);
+            end
+			
+			if 1==probetype
+				auto_reject(DMT_DOF_SPEC_OVERLOAD~=0)='D';
+			end
+			
+			if iCreateAspectRatio
+				aspectRatio = netcdf.getVar(f,netcdf.inqVarID(f,'image_RectangleW'),start,count)./netcdf.getVar(f,netcdf.inqVarID(f,'image_RectangleL'),start,count);
+				aspectRatio1 = netcdf.getVar(f,netcdf.inqVarID(f,'image_EllipseW'),start,count)./netcdf.getVar(f,netcdf.inqVarID(f,'image_EllipseL'),start,count);
+			end
+			
+			
+			if 0==probetype
+				int_arr=Time_in_seconds;
 			else
-				Time_in_seconds2 = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start-1,count+1);
-				int_arr = diff(Time_in_seconds2);
+				if start-1 <= 0
+					int_arr = [0;diff(Time_in_seconds)];
+					int_arr2 = []; %Won't bother reaccepting particles at the beginning or end of dataset
+				else
+					Time_in_seconds2 = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start-1,count+1);
+					int_arr = diff(Time_in_seconds2);
+					
+					if start ~= start_all(end)
+						Time_in_seconds3 = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),(start+count)-1,2);
+						int_arr2 = diff(Time_in_seconds3); %Single value describing interarrival time of first particle of next 1-sec period
+					else
+						int_arr2 = [];
+					end
+				end
 				
-				if start ~= start_all(end)
-					Time_in_seconds3 = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),(start+count)-1,2);						
-					int_arr2 = diff(Time_in_seconds3); %Single value describing interarrival time of first particle of next 1-sec period
-				else
-					int_arr2 = [];
+				int_arr2(int_arr2<0)=0;
+				
+				if reaccptShatrs
+					if start ~= start_all(end)
+						Time_in_seconds4 = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start,count+1);
+						int_arr3 = diff(Time_in_seconds4);
+					else
+						Time_in_seconds4 = Time_in_seconds;
+						int_arr3 = diff(Time_in_seconds4);
+						int_arr3 = [int_arr3;int_arr3(end)];
+					end
+					int_arr3(int_arr3<0)=0;
 				end
+				
+			end
+			%         if 2==probetype
+			%           int_arr=int_arr*(res/10^6/170);
+			%         end
+			
+			if 2==probetype
+				int_arr(int_arr<-10)=int_arr(int_arr<-10)+(2^32-1)*(res/10^6/tasMax);
+			elseif 0==probetype
+				int_arr(int_arr<0)=int_arr(int_arr<0)+(2^24-1)*(res/10^6/tasMax);
 			end
 			
-			int_arr2(int_arr2<0)=0;
-			
-			if reaccptShatrs
-				if start ~= start_all(end)
-					Time_in_seconds4 = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start,count+1);
-					int_arr3 = diff(Time_in_seconds4);  
-				else
-					Time_in_seconds4 = Time_in_seconds;
-					int_arr3 = diff(Time_in_seconds4);  
-					int_arr3 = [int_arr3;int_arr3(end)];
-				end
-				int_arr3(int_arr3<0)=0;
+			if sum(int_arr<0)>0
+				fprintf(2,'\nAt index %d number of int_arr < 0: %d\n',i,sum(int_arr<0));
+				disp([int_arr(int_arr<0),int_arr(int_arr<0)+(2^32-1)*(res/10^6/tasMax)]);
+			elseif sum(int_arr>1)>0
+				sumIntArrGT1 = sumIntArrGT1 + sum(int_arr > 1);
+				tempLocs = find(int_arr > 1);
+				intArrGT1 = vertcat(intArrGT1,int_arr(tempLocs));
+				
+				%             fprintf(2,'\nAt index %d number of int_arr > 1: %d\n',i,sum(int_arr>1));
+				%             disp([int_arr(int_arr>1)-(2^32-1)*(res/10^6/tasMax), int_arr(int_arr>1), Time_in_seconds(int_arr>1)/(0.15/(10^3)/170), Time_in_seconds((int_arr>1))/(0.15/(10^3)/170)]);
 			end
 			
-        end
-%         if 2==probetype 
-%           int_arr=int_arr*(res/10^6/170); 
-%         end
-        
-        if 2==probetype
-            int_arr(int_arr<-10)=int_arr(int_arr<-10)+(2^32-1)*(res/10^6/tasMax);
-        elseif 0==probetype
-            int_arr(int_arr<0)=int_arr(int_arr<0)+(2^24-1)*(res/10^6/tasMax);            
-        end
-            
-        if sum(int_arr<0)>0
-			fprintf(2,'\nAt index %d number of int_arr < 0: %d\n',i,sum(int_arr<0));
-            disp([int_arr(int_arr<0),int_arr(int_arr<0)+(2^32-1)*(res/10^6/tasMax)]);
-        elseif sum(int_arr>1)>0
-			sumIntArrGT1 = sumIntArrGT1 + sum(int_arr > 1);
-			tempLocs = find(int_arr > 1); 
-			intArrGT1 = vertcat(intArrGT1,int_arr(tempLocs));
+			%         auto_reject(int_arr<0 | int_arr>1)='I';
+			auto_reject(int_arr<0)='I';
+			int_arr(int_arr<0)=0;
+			%         int_arr(int_arr>1)=0;
 			
-%             fprintf(2,'\nAt index %d number of int_arr > 1: %d\n',i,sum(int_arr>1));
-%             disp([int_arr(int_arr>1)-(2^32-1)*(res/10^6/tasMax), int_arr(int_arr>1), Time_in_seconds(int_arr>1)/(0.15/(10^3)/170), Time_in_seconds((int_arr>1))/(0.15/(10^3)/170)]);
-        end
-        
-%         auto_reject(int_arr<0 | int_arr>1)='I';
-		auto_reject(int_arr<0)='I';
-        int_arr(int_arr<0)=0;
-%         int_arr(int_arr>1)=0;
-
-
-%         max_dimension = im_width;
-%         max_dimension(im_length>im_width)=im_length(im_length>im_width);
-
-        
-        % Size definition chosen based on the d_choice given in the function call
-        if 1==d_choice
-            particle_diameter_minR = im_length * diodesize; %(im_length+
-        elseif 2==d_choice
-            particle_diameter_minR = im_width * diodesize; %(im_length+
-        elseif 3==d_choice
-            particle_diameter_minR = (im_length + im_width)/2 * diodesize; %(im_length+
-        elseif 4==d_choice
-            particle_diameter_minR = sqrt(im_width.^2+im_length.^2) * diodesize; %(im_length+
-        elseif 5==d_choice
-            particle_diameter_minR = max(im_width, im_length) * diodesize; %(im_length+
-        elseif 6==d_choice
-            particle_diameter_minR = netcdf.getVar(f,netcdf.inqVarID(f,'image_diam_minR'),start,count); % * diodesize
-        end
-        
-%         if 1==strcmp('2DC',probename)  % Adjust resolution from 25 to 30
-%            particle_diameter_minR=particle_diameter_minR*1.2;
-%            area = area*1.44;
-%         end
-
-
-
-        % Legacy: Added for Paris meeting, 08/25/2014
-        % Used in intercomparison with Environment Canada and University of Blaise Pascal
-        %{
+			
+			%         max_dimension = im_width;
+			%         max_dimension(im_length>im_width)=im_length(im_length>im_width);
+			
+			
+			% Size definition chosen based on the d_choice given in the function call
+			if 1==d_choice
+				particle_diameter_minR = im_length * diodesize; 
+			elseif 2==d_choice
+				particle_diameter_minR = im_width * diodesize;
+			elseif 3==d_choice
+				particle_diameter_minR = (im_length + im_width)/2 * diodesize;
+			elseif 4==d_choice
+				particle_diameter_minR = sqrt(im_width.^2+im_length.^2) * diodesize;
+			elseif 5==d_choice
+				particle_diameter_minR = max(im_width, im_length) * diodesize; 
+			elseif 6==d_choice
+				particle_diameter_minR = netcdf.getVar(f,netcdf.inqVarID(f,'image_diam_minR'),start,count); % Units of mm
+			end
+			
+			%         if 1==strcmp('2DC',probename)  % Adjust resolution from 25 to 30
+			%            particle_diameter_minR=particle_diameter_minR*1.2;
+			%            area = area*1.44;
+			%         end
+			
+			
+			
+			% Legacy: Added for Paris meeting, 08/25/2014
+			% Used in intercomparison with Environment Canada and University of Blaise Pascal
+			%{
         diffPartCount=[1;diff(Particle_count)];
         time_interval22(i) = (Time_in_seconds(end)-Time_in_seconds(1));
         time_interval32(i) = sum(int_arr(diffPartCount==1));
         time_interval42(i) = sum(int_arr);
         time_interval52(i) = sum(int_arr(diffPartCount~=1));
         time_interval62(i) = sum(int_arr(DMT_DOF_SPEC_OVERLOAD==0));
-        lengthForTemp = im_length * diodesize; 
+        lengthForTemp = im_length * diodesize;
         particle_diameter_minR(entirein~=0)=lengthForTemp(entirein~=0);
         
         if time_interval22(i)<0
@@ -784,7 +829,7 @@ for i=1:length(tas)
 
         if 1==probetype
             image_time_hhmmss    = netcdf.getVar(f,netcdf.inqVarID(f,'particle_time'),start,count);
-            image_time_hhmmssnew = netcdf.getVar(f,netcdf.inqVarID(f,'particle_time'),start,count); 
+            image_time_hhmmssnew = netcdf.getVar(f,netcdf.inqVarID(f,'particle_time'),start,count);
 
         elseif 2==probetype
             alltimeinseconds = netcdf.getVar(f,netcdf.inqVarID(f,'Time_in_seconds'),start,count);
@@ -794,146 +839,149 @@ for i=1:length(tas)
             image_time_hhmmss = insec2hhmmss(image_time_hhmmss);
             image_time_hhmmssnew = image_time_hhmmss;
         end
-        %}
-        if probetype==0 % skip reading variable if 2DC/2DP - Joe Finlon - 06/26/17
-            time_interval72(i) = 0; % 2DC/2DP does not have overload flag
-        else
-            time_interval72(i) = sum(int_arr(DMT_DOF_SPEC_OVERLOAD~=0));
-        end
-        
-        % Simplified by DS - Removed image_time_hhmmssnew as it was defined by and never changed from image_time_hhmmss
-        image_time_hhmmss = image_time_hhmmssall(start+1:start+count);
-        
-        % If image time crosses midnight, add 240000 to all times past midnight
-%         image_time_hhmmss(image_time_hhmmss<10000)=image_time_hhmmss(image_time_hhmmss<10000)+240000;
-
-        
-        
-        % Save an intermediate output file every 8000 steps through the loop
-        if i==8000
-            save([outfile(1:end-3) 'tempComp.mat']);
-        end
-        
-        %% Calculate area of particle according to image reconstruction and airspeed (if tasMax exceeded)
-
-        % Correct for airspeeds exceeding the max airspeed for the probe
-        if(tas(i) > tasMax) % Set to threshold as necessary - stretch area of particle
-			fprintf(2,'TAS at tas index %d exceeds tasMax (%.1f) of probe. Reconstructing area...\n\n',...
-				i,tasMax);
-            area = area*tas(i)/tasMax;
-        end
-
-        particle_mass = area*0;
-        calcd_area = area*0;
-        for iiii=1:length(area)
-           particle_mass(iiii)=single_mass(particle_diameter_minR(iiii)/10, habit1(iiii));  % in unit of gram
-           calcd_area(iiii)=single_area(particle_diameter_minR(iiii)/10, habit1(iiii));  % in unit of mm^2         
-        end
-        particle_massbl=0.115/1000*area.^(1.218); % in unit of gram
-
-
-        %% Added by Robert Jackson -- old version did not have area ratio code
-        area_ratio = area./(pi/4.*particle_diameter_minR.^2);
-        auto_reject(area_ratio < .2) = 'z';
-        
-        %% Added by Will to calculate terminal velocity and precipitation rate
-        particle_vt = area*0;
-        for iiii=1:length(area)
-           particle_vt(iiii)=single_vt(particle_diameter_minR(iiii)/1000, area_ratio(iiii), particle_mass(iiii)/1000,Pres(i),Temp(i));  % in unit of gram
-        end
-        particle_pr=particle_mass.*particle_vt;
-
-        
-        %% Time-dependent threshold for interarrival time - Added by Dan Stechman - 5/10/16 & Modified by Joe Finlon - 03/03/17
-		% Enable this section to use a time-dependent threshold for interarrival time. Also need to enable section at top of
-		% script allowing for threshold file to be pulled in
-		
-        % Ingest previously calculated interarrival time threshold and flag in auto_reject appropriately to remove particle
-		% flagged with short inter arrv time, and the one immediately before it
-        
-        if applyIntArrThresh && length(varargin) == 1 && strcmp(iaThreshFile,'NONE') == 0
-            auto_reject_preIAT = auto_reject;
-			iaThresh_ncid = netcdf.open(iaThreshFile,'nowrite');
-			iaThresh = netcdf.getVar(iaThresh_ncid,netcdf.inqVarID(iaThresh_ncid,'threshold'),start,count);
-			netcdf.close(iaThresh_ncid);
-		
-            if ((length(int_arr) == 1) && (int_arr(1) <= iaThresh(1)))
-				auto_reject(1) = 'S';
+			%}
+			if probetype==0 % skip reading variable if 2DC/2DP - Joe Finlon - 06/26/17
+                time_interval72(i) = 0; % 2DC/2DP does not have overload flag
             else
-                if int_arr(1) <= iaThresh(1)
-					auto_reject(1) = 'S';
-                end
-		
-                for ix = 2:length(int_arr)
-					if int_arr(ix) <= iaThresh(ix)
-						auto_reject((ix-1):ix) = 'S';
-					end
-                end
+                time_interval72(i) = sum(int_arr(DMT_DOF_SPEC_OVERLOAD~=0));
             end
-            
-            % Experimental option to reaccept particles flagged as shattered which may in fact be the result of diffraction
-			% fringes
-			% Added by Dan Stechman - 6/8/2015 & Modified by Joe Finlon - 03/03/17 - with base code by Wei Wu
-			if reaccptShatrs
-				% Start by defining the indices for the beginning and end of individual shattering events
-				rBegin = ((int_arr > iaThresh & int_arr3 < iaThresh));
-				rEnd = ((int_arr < iaThresh & int_arr3 > iaThresh));
-				
-				maxParticle = reaccptD;
-				eIndex = [];
-				
-				% We search through each individual set of shattering events and check to see if any of the particles are both
-				% larger than the reacceptance diameter and have an interarrival time less than the reacceptance threshold as we'd
-				% expect diffraction fringes to be larger than shattered particles and to have a particularly small interarrival time
-                for iEvent = find(rBegin):find(rEnd)
-					if ((particle_diameter_minR(iEvent) > maxParticle) && (int_arr(iEvent) < reaccptMaxIA))
-						maxParticle = particle_diameter_minR(iEvent);
-						eIndex = iEvent;
-					end
-                end
-
-				auto_reject(eIndex) = 'R';
+			
+			% Simplified by DS - Removed image_time_hhmmssnew as it was defined by and never changed from image_time_hhmmss
+			image_time_hhmmss = image_time_hhmmssall(start+1:start+count);
+			
+			% If image time crosses midnight, add 240000 to all times past midnight
+			%         image_time_hhmmss(image_time_hhmmss<10000)=image_time_hhmmss(image_time_hhmmss<10000)+240000;
+			
+			
+			
+			% Save an intermediate output file every 8000 steps through the loop
+			if i==8000
+				save([outfile(1:end-3) 'tempComp.mat']);
 			end
 			
-        
-			% Following vars used for verifying shatter removal and reacceptance in external script - can be commented out if desired
+			%% Calculate area of particle according to image reconstruction and airspeed (if tasMax exceeded)
 			
-            shatterLocs = find(auto_reject == 'S');
-			shatterIA = int_arr(shatterLocs);
-			shatterTimes = Time_in_seconds(shatterLocs);
-            shatterDiam = particle_diameter_minR(shatterLocs);
+			% Correct for airspeeds exceeding the max airspeed for the probe
+			if(tas(i) > tasMax) % Set to threshold as necessary - stretch area of particle
+				fprintf(2,'TAS at tas index %d exceeds tasMax (%.1f) of probe. Reconstructing area...\n\n',...
+					i,tasMax);
+				area = area*tas(i)/tasMax;
+			end
+			
+			particle_mass_ice = area*0;
+			particle_mass_lw = area*0;
+			calcd_area = area*0;
+			for iiii=1:length(area)
+				particle_mass_ice(iiii)=single_mass(particle_diameter_minR(iiii)/10, habit1(iiii));  % in unit of gram
+				particle_mass_lw(iiii) = (pi/6) * (particle_diameter_minR(iiii)/10)^3;
+				calcd_area(iiii)=single_area(particle_diameter_minR(iiii)/10, habit1(iiii));  % in unit of mm^2
+			end
+			particle_massbl=0.115/1000*area.^(1.218); % in unit of gram
+			
+			
+			%% Added by Robert Jackson -- old version did not have area ratio code
+			area_ratio = area./(pi/4.*particle_diameter_minR.^2);
+			auto_reject(area_ratio < .2) = 'z';
+			
+			%% Added by Will to calculate terminal velocity and precipitation rate
+			particle_vt_ice = area*0;
+			particle_vt_lw = area*0;
+			for iiii=1:length(area)
+				particle_vt_ice(iiii)=single_vt(particle_diameter_minR(iiii)/1000, area_ratio(iiii), particle_mass_ice(iiii)/1000,Pres(i),Temp(i));  % in unit of gram
+				particle_vt_lw(iiii)=single_vt(particle_diameter_minR(iiii)/1000, area_ratio(iiii), particle_mass_lw(iiii)/1000,Pres(i),Temp(i)); % Not sure if this function applies to liquid water or not...
+			end
+			particle_pr_ice=particle_mass_ice.*particle_vt_ice;
+			particle_pr_lw=particle_mass_lw.*particle_vt_lw;
+			
+			%% Time-dependent threshold for interarrival time - Added by Dan Stechman - 5/10/16 & Modified by Joe Finlon - 03/03/17
+            % Enable this section to use a time-dependent threshold for interarrival time. Also need to enable section at top of
+            % script allowing for threshold file to be pulled in
+        
+            % Ingest previously calculated interarrival time threshold and flag in auto_reject appropriately to remove particle
+            % flagged with short inter arrv time, and the one immediately before it
+        
+            if applyIntArrThresh && length(varargin) == 1 && strcmp(iaThreshFile,'NONE') == 0
+                auto_reject_preIAT = auto_reject;
+                iaThresh_ncid = netcdf.open(iaThreshFile,'nowrite');
+                iaThresh = netcdf.getVar(iaThresh_ncid,netcdf.inqVarID(iaThresh_ncid,'threshold'),start,count);
+                netcdf.close(iaThresh_ncid);
+        
+                if ((length(int_arr) == 1) && (int_arr(1) <= iaThresh(1)))
+                    auto_reject(1) = 'S';
+                else
+                    if int_arr(1) <= iaThresh(1)
+                        auto_reject(1) = 'S';
+                    end
+        
+                    for ix = 2:length(int_arr)
+                        if int_arr(ix) <= iaThresh(ix)
+                            auto_reject((ix-1):ix) = 'S';
+                        end
+                    end
+                end
             
-			shatrReject_times = vertcat(shatrReject_times, shatterTimes);
-			shatrReject_intArr = vertcat(shatrReject_intArr, shatterIA);
-            shatrReject_diam = vertcat(shatrReject_diam, shatterDiam);
+                % Experimental option to reaccept particles flagged as shattered which may in fact be the result of diffraction
+                % fringes
+                % Added by Dan Stechman - 6/8/2015 & Modified by Joe Finlon - 03/03/17 - with base code by Wei Wu
+                if reaccptShatrs
+                    % Start by defining the indices for the beginning and end of individual shattering events
+                    rBegin = ((int_arr > iaThresh & int_arr3 < iaThresh));
+                    rEnd = ((int_arr < iaThresh & int_arr3 > iaThresh));
+                
+                    maxParticle = reaccptD;
+                    eIndex = [];
+                
+                    % We search through each individual set of shattering events and check to see if any of the particles are both
+                    % larger than the reacceptance diameter and have an interarrival time less than the reacceptance threshold as we'd
+                    % expect diffraction fringes to be larger than shattered particles and to have a particularly small interarrival time
+                    for iEvent = find(rBegin):find(rEnd)
+                        if ((particle_diameter_minR(iEvent) > maxParticle) && (int_arr(iEvent) < reaccptMaxIA))
+                            maxParticle = particle_diameter_minR(iEvent);
+                            eIndex = iEvent;
+                        end
+                    end
+
+                    auto_reject(eIndex) = 'R';
+                end
             
-            rccptLocs = find(auto_reject == 'R');
-			rccptIA = int_arr(rccptLocs);
-			rccptTimes = Time_in_seconds(rccptLocs);
-            rccptDiam = particle_diameter_minR(rccptLocs);
+        
+                % Following vars used for verifying shatter removal and reacceptance in external script - can be commented out if desired
             
-			rccptReject_times = vertcat(rccptReject_times, rccptTimes);
-			rccptReject_intArr = vertcat(rccptReject_intArr, rccptIA);
-            rccptReject_diam = vertcat(rccptReject_diam, rccptDiam);
+                shatterLocs = find(auto_reject == 'S');
+                shatterIA = int_arr(shatterLocs);
+                shatterTimes = Time_in_seconds(shatterLocs);
+                shatterDiam = particle_diameter_minR(shatterLocs);
+            
+                shatrReject_times = vertcat(shatrReject_times, shatterTimes);
+                shatrReject_intArr = vertcat(shatrReject_intArr, shatterIA);
+                shatrReject_diam = vertcat(shatrReject_diam, shatterDiam);
+            
+                rccptLocs = find(auto_reject == 'R');
+                rccptIA = int_arr(rccptLocs);
+                rccptTimes = Time_in_seconds(rccptLocs);
+                rccptDiam = particle_diameter_minR(rccptLocs);
+            
+                rccptReject_times = vertcat(rccptReject_times, rccptTimes);
+                rccptReject_intArr = vertcat(rccptReject_intArr, rccptIA);
+                rccptReject_diam = vertcat(rccptReject_diam, rccptDiam);
             
                         
-			loopedTimes = vertcat(loopedTimes, Time_in_seconds);
-			loopedIntArr = vertcat(loopedIntArr, int_arr);
-            loopedDiam = vertcat(loopedDiam, particle_diameter_minR);
-			loopedAutoRej = vertcat(loopedAutoRej, auto_reject);
+                loopedTimes = vertcat(loopedTimes, Time_in_seconds);
+                loopedIntArr = vertcat(loopedIntArr, int_arr);
+                loopedDiam = vertcat(loopedDiam, particle_diameter_minR);
+                loopedAutoRej = vertcat(loopedAutoRej, auto_reject);
             
-        end
-        
-   
-        %% Legacy interarrival time integrity analysis 
-        %{
+            end
+			
+			%% Legacy interarrival time integrity analysis
+			%{
         % Time and interarrival calculation. Modified by Will Wu 11/12/2013
         % Simplified (tested/changed by DS)
         if strcmp(probename,'2DC')==1 || strcmp(probename,'2DP')==1 || strcmp(probename,'F2DC')==1
             fracseccc= netcdf.getVar(f,netcdf.inqVarID(f,'msec'),start,count);
             image_timeia = hhmmss2insec(image_time_hhmmss)+fracseccc*1e-2; % for 2DC
         elseif strcmp(probename,'CIP')==1 || strcmp(probename,'PIP')==1
-            image_timeia = hhmmss2insec(image_time_hhmmss)+msec*1e-3+microsec; % for CIP 
+            image_timeia = hhmmss2insec(image_time_hhmmss)+msec*1e-3+microsec; % for CIP
         else
             image_timeia = hhmmss2insec(image_time_hhmmss)+msec*1e-3+microsec/10^6; % for HVPS
         end
@@ -952,7 +1000,7 @@ for i=1:length(tas)
                int_arr(rec_particles(1)) = 0;
            end
 
-           if (strcmp(probename,'CIP')==1 || strcmp(probename,'PIP')==1 || strcmp(probename,'HVPS')==1 ) % 2DC use the interarrival time for every particles, not absolute time 
+           if (strcmp(probename,'CIP')==1 || strcmp(probename,'PIP')==1 || strcmp(probename,'HVPS')==1 ) % 2DC use the interarrival time for every particles, not absolute time
 
                if(isempty(rec_particles))
                  sum_int_arr_good = 0;
@@ -962,7 +1010,7 @@ for i=1:length(tas)
                if ~(sum_int_arr_good >= .6*sum_arr && sum_int_arr_good <= 1.4*sum_arr)
                  auto_reject(rec_particles) = 'I';
                  %disp(['Record ' num2str(itemp) ' thrown out: Accepted time = ' num2str(sum_int_arr_good) ' total time = ' num2str(sum_arr)]);
-                 nThrow=nThrow+1;  
+                 nThrow=nThrow+1;
                  nThrow11=nThrow11+1;
                end
 
@@ -974,560 +1022,595 @@ for i=1:length(tas)
         totalint(i)=sum_int_arr_good;
         intsum(i)=sum_arr;
         save('intarrhvps.mat','int_arr')
-        %}
-        
-        %% Shatter identification and removal - Added by Dan Stechman on 5/31/2016
-        % Currently this is spiral-dependent and uses a threshold defined in the header of this script
-        % Flag particles as shattered if their interarrival time is less than or equal to the threshold. Also flag the particle
-        % immediately before the target particle.
-        %{
-        if applyIntArrThresh
-			% If the first particle in the next 1-sec period has a small interarrival time, we flag the last particle of
-			% the current period as shattered as well
-			if ~isempty(int_arr2)
-				if int_arr2 <= intar_threshold(i)
-					auto_reject(end) = 'S';
+			%}
+			
+			%% Shatter identification and removal - Added by Dan Stechman on 5/31/2016
+			% Currently this is spiral-dependent and uses a threshold defined in the header of this script
+			% Flag particles as shattered if their interarrival time is less than or equal to the threshold. Also flag the particle
+			% immediately before the target particle.
+			if applyIntArrThresh && length(varargin) == 0 && strcmp(iaThreshFile,'NONE') == 1
+				% If the first particle in the next 1-sec period has a small interarrival time, we flag the last particle of
+				% the current period as shattered as well
+				if ~isempty(int_arr2)
+					if int_arr2 <= intar_threshold(i)
+						auto_reject(end) = 'S';
+					end
 				end
-			end
-
-			if (length(int_arr) == 1 && int_arr(1) <= intar_threshold(i)) 
-				auto_reject(1) = 'S';
-			else
-				if int_arr(1) <= intar_threshold(i)
+				
+				if (length(int_arr) == 1 && int_arr(1) <= intar_threshold(i))
 					auto_reject(1) = 'S';
-				end
-
-				for ix = 2:length(int_arr)
-					if int_arr(ix) <= intar_threshold(i)
-						auto_reject(ix-1:ix) = 'S';
+				else
+					if int_arr(1) <= intar_threshold(i)
+						auto_reject(1) = 'S';
+					end
+					
+					for ix = 2:length(int_arr)
+						if int_arr(ix) <= intar_threshold(i)
+							auto_reject(ix-1:ix) = 'S';
+						end
 					end
 				end
-			end
-
-			
-			% Experimental option to reaccept particles flagged as shattered which may in fact be the result of diffraction
-			% fringes
-			% Added by Dan Stechman - 6/8/2015 - with base code by Wei Wu
-			if reaccptShatrs
-				% Start by defining the indices for the beginning and end of individual shattering events
-				rBegin = ((int_arr > intar_threshold(i) & int_arr3 < intar_threshold(i)));
-				rEnd = ((int_arr < intar_threshold(i) & int_arr3 > intar_threshold(i)));
 				
-				maxParticle = reaccptD;
-				eIndex = [];
 				
-				% We search through each individual set of shattering events and check to see if any of the particles are both
-				% larger than the reacceptance diameter and have an interarrival time less than the reacceptance threshold as we'd
-				% expect diffraction fringes to be larger than shattered particles and to have a particularly small interarrival time
-				for iEvent = find(rBegin):find(rEnd)
-					if ((particle_diameter_minR(iEvent) > maxParticle) && (int_arr(iEvent) < reaccptMaxIA))
-						maxParticle = particle_diameter_minR(iEvent);
-						eIndex = iEvent;
+				% Experimental option to reaccept particles flagged as shattered which may in fact be the result of diffraction
+				% fringes
+				% Added by Dan Stechman - 6/8/2015 - with base code by Wei Wu
+				if reaccptShatrs
+					% Start by defining the indices for the beginning and end of individual shattering events
+					rBegin = ((int_arr > intar_threshold(i) & int_arr3 < intar_threshold(i)));
+					rEnd = ((int_arr < intar_threshold(i) & int_arr3 > intar_threshold(i)));
+					
+					maxParticle = reaccptD;
+					eIndex = [];
+					
+					% We search through each individual set of shattering events and check to see if any of the particles are both
+					% larger than the reacceptance diameter and have an interarrival time less than the reacceptance threshold as we'd
+					% expect diffraction fringes to be larger than shattered particles and to have a particularly small interarrival time
+					for iEvent = find(rBegin):find(rEnd)
+						if ((particle_diameter_minR(iEvent) > maxParticle) && (int_arr(iEvent) < reaccptMaxIA))
+							maxParticle = particle_diameter_minR(iEvent);
+							eIndex = iEvent;
+						end
 					end
+					
+					auto_reject(eIndex) = 'R';
 				end
-
-				auto_reject(eIndex) = 'R';
+				
+				
+				% Following vars used for verifying shatter removal and reacceptance in external script - can be commented out if desired
+				shatterLocs = find(auto_reject == 'S');
+				shatterIA = int_arr(shatterLocs);
+				shatterTimes = Time_in_seconds(shatterLocs);
+				shatterDiam = particle_diameter_minR(shatterLocs);
+				
+				shatrReject_times = vertcat(shatrReject_times, shatterTimes);
+				shatrReject_intArr = vertcat(shatrReject_intArr, shatterIA);
+				shatrReject_diam = vertcat(shatrReject_diam, shatterDiam);
+				
+				rccptLocs = find(auto_reject == 'R');
+				rccptIA = int_arr(rccptLocs);
+				rccptTimes = Time_in_seconds(rccptLocs);
+				rccptDiam = particle_diameter_minR(rccptLocs);
+				
+				rccptReject_times = vertcat(rccptReject_times, rccptTimes);
+				rccptReject_intArr = vertcat(rccptReject_intArr, rccptIA);
+				rccptReject_diam = vertcat(rccptReject_diam, rccptDiam);
+				
+				
+				loopedTimes = vertcat(loopedTimes, Time_in_seconds);
+				loopedIntArr = vertcat(loopedIntArr, int_arr);
+				loopedDiam = vertcat(loopedDiam, particle_diameter_minR);
+				loopedAutoRej = vertcat(loopedAutoRej, auto_reject);
 			end
 			
-        
-			% Following vars used for verifying shatter removal and reacceptance in external script - can be commented out if desired
-			shatterLocs = find(auto_reject == 'S');
-			shatterIA = int_arr(shatterLocs);
-			shatterTimes = Time_in_seconds(shatterLocs);
-            shatterDiam = particle_diameter_minR(shatterLocs);
-            
-			shatrReject_times = vertcat(shatrReject_times, shatterTimes);
-			shatrReject_intArr = vertcat(shatrReject_intArr, shatterIA);
-            shatrReject_diam = vertcat(shatrReject_diam, shatterDiam);
-            
-            rccptLocs = find(auto_reject == 'R');
-			rccptIA = int_arr(rccptLocs);
-			rccptTimes = Time_in_seconds(rccptLocs);
-            rccptDiam = particle_diameter_minR(rccptLocs);
-            
-			rccptReject_times = vertcat(rccptReject_times, rccptTimes);
-			rccptReject_intArr = vertcat(rccptReject_intArr, rccptIA);
-            rccptReject_diam = vertcat(rccptReject_diam, rccptDiam);
-            
-                        
-			loopedTimes = vertcat(loopedTimes, Time_in_seconds);
-			loopedIntArr = vertcat(loopedIntArr, int_arr);
-            loopedDiam = vertcat(loopedDiam, particle_diameter_minR);
-			loopedAutoRej = vertcat(loopedAutoRej, auto_reject);
-        end
-        %}
-
-        %% Apply rejection criteria and identify good and bad particles 
-        % Modify the next line to include/exclude any particles you see fit. 
-        
-        good_particles = (auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' | auto_reject == 'R');
-        bad_particles = ~(auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' | auto_reject == 'R');
-% 		bad_particles = (auto_reject == 'S');
-        
-        % Legacy: Rejection criteria used in the past
-        %{
+			
+			%% Apply rejection criteria and identify good and bad particles
+			% Modify the next line to include/exclude any particles you see fit.
+			
+			%         good_particles = (auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' | auto_reject == 'R');
+			good_particles = ( (auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' | auto_reject == 'R') & particle_diameter_minR > 0.15);
+			if iCreateBad
+				% 			bad_particles = ~(auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' | auto_reject == 'R');
+				bad_particles = ~( (auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' | auto_reject == 'R') & particle_diameter_minR > 0.15);
+				%	 		bad_particles = (auto_reject == 'S');
+			end
+			
+			% Legacy: Rejection criteria used in the past
+			%{
         %if RejectCriterier==0
         %    good_particles = (auto_reject ~= 'c'); %  &  centerin==1; % & int_arr > 1e-5 int_arr > 1e-5 &
         %else
-        %    good_particles = (auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' & int_arr > intar_threshold) % | auto_reject == 'u'); % & centerin==1; % & int_arr > 1e-5; 
+        %    good_particles = (auto_reject == '0' | auto_reject == 'H' | auto_reject == 'h' | auto_reject == 'u' & int_arr > intar_threshold) % | auto_reject == 'u'); % & centerin==1; % & int_arr > 1e-5;
         %end
-        %}
-        
-        
-        if SAmethod==0
-            good_particles = good_particles & centerin==1;
-            bad_particles = bad_particles & centerin==1;
-        elseif SAmethod==1
-            good_particles = good_particles & entirein==0;
-            bad_particles = bad_particles & centerin==0;
-        end
-        
-        good_partpercent(i)=sum(good_particles)/length(good_particles);
-        
-        rejectpercentbycriterion(i,1)=sum(centerin==1)/length(good_particles);
-        rejectpercentbycriterion(i,2)=sum(auto_reject == '0')/length(good_particles);
-        rejectpercentbycriterion(i,3)=sum(auto_reject == 'H')/length(good_particles);
-        rejectpercentbycriterion(i,4)=sum(auto_reject == 'h')/length(good_particles);
-        rejectpercentbycriterion(i,5)=sum(auto_reject == 'u')/length(good_particles);
-        rejectpercentbycriterion(i,6)=sum(auto_reject == 'a')/length(good_particles);
-        rejectpercentbycriterion(i,7)=sum(auto_reject == 't')/length(good_particles);
-        rejectpercentbycriterion(i,8)=sum(auto_reject == 'p')/length(good_particles);
-        rejectpercentbycriterion(i,9)=sum(auto_reject == 's')/length(good_particles);
-        rejectpercentbycriterion(i,10)=sum(auto_reject == 'z')/length(good_particles);
-        rejectpercentbycriterion(i,11)=sum(auto_reject == 'i')/length(good_particles);
-        rejectpercentbycriterion(i,12)=sum(auto_reject == 'A')/length(good_particles);
-        rejectpercentbycriterion(i,13)=sum(auto_reject == 'S')/length(good_particles); %Shattered - Added DS
-		rejectpercentbycriterion(i,14)=sum(auto_reject == 'R')/length(good_particles); %Reaccepted - Added DS
-        
-        numGoodparticles(i)=length(good_particles);
-        numBadparticles(i)=length(bad_particles);
-%         disp([int32(timehhmmss(i)), sum(good_particles),length(good_particles),length(good_particles)-sum(good_particles)]);
-
-        image_time = hhmmss2insec(image_time_hhmmss);
-
-        % Good (accepted) particles
-        good_image_times = image_time(good_particles);
-        good_particle_diameter_minR = particle_diameter_minR(good_particles);
-        good_particle_diameter_AreaR = particle_diameter_AreaR(good_particles);
-        good_int_arr=int_arr(good_particles);
-        good_ar = area_ratio(good_particles);
-        good_area = area(good_particles);
-        good_perimeter = perimeter(good_particles);
-        if iCreateAspectRatio == 1
-        good_AspectRatio = aspectRatio(good_particles & entirein==0);        
-        good_AspectRatio1 = aspectRatio1(good_particles & entirein==0);
-        end
-        good_ar1 = area_ratio(good_particles & entirein==0);
-        good_image_times1 = image_time(good_particles  & entirein==0);
-        good_iwc=particle_mass(good_particles);
-        good_partarea=calcd_area(good_particles);
-        good_iwcbl=particle_massbl(good_particles);
-        good_vt=particle_vt(good_particles);
-        good_pr=particle_pr(good_particles);        
-        good_habit=habit1(good_particles);
-        
-        good_particle_diameter=good_particle_diameter_minR;
-        good_particle_diameter1 = particle_diameter_minR(good_particles  & entirein==0);
-        
-        if iCreateBad == 1
-        % Bad (rejected) particles
-        bad_image_times = image_time(bad_particles);
-        bad_particle_diameter_minR = particle_diameter_minR(bad_particles);
-        bad_particle_diameter_AreaR = particle_diameter_AreaR(bad_particles);
-        bad_int_arr=int_arr(bad_particles);
-        bad_ar = area_ratio(bad_particles);
-        bad_area = area(bad_particles);
-        bad_perimeter = perimeter(bad_particles);
-        if iCreateAspectRatio == 1 % added if statement if not creating aspect ratio - Joe Finlon - 03/03/17
-        bad_AspectRatio = aspectRatio(bad_particles & entirein==0);        
-        bad_AspectRatio1 = aspectRatio1(bad_particles & entirein==0);
-        end
-        bad_ar1 = area_ratio(bad_particles & entirein==0);
-        bad_image_times1 = image_time(bad_particles  & entirein==0);
-        bad_iwc=particle_mass(bad_particles);
-        bad_partarea=calcd_area(bad_particles);
-        bad_iwcbl=particle_massbl(bad_particles);
-        bad_vt=particle_vt(bad_particles);
-        bad_pr=particle_pr(bad_particles);        
-        bad_habit=habit1(bad_particles);
-        
-        bad_particle_diameter=bad_particle_diameter_minR;
-        bad_particle_diameter1 = particle_diameter_minR(bad_particles  & entirein==0);
-        end
-        %% Perform various status and error checks
-        if mod(i,1000) == 0
-			fprintf('%d/%d | %s\n',i,one_sec_dur,datestr(now));
-        end
-        
-        total_one_sec_locs(i) = length(find(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)));
-        time_interval2(i) = sum(int_arr(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)));
-
-        if sum(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)) ~= length(image_time)
-			fprintf(2,'%d / %d\tError on sizing at index %d\n',sum(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)),length(image_time),i);
-        end
-
-        if(total_one_sec_locs(i) == 0)
-         time_interval2(i) = 1;
-        end
-
-        %% Sort good (accepted) particles into size distributions
-        good_one_sec_locs = find(good_image_times >= one_sec_times(i) & good_image_times < one_sec_times(i+1));
-        good_one_sec_locs1 = find(good_image_times1 >= one_sec_times(i) & good_image_times1 < one_sec_times(i+1));
-        
-        goodintpercent(i) = sum(good_int_arr(good_image_times >= one_sec_times(i) & good_image_times < one_sec_times(i+1)))/time_interval2(i);
-
-        one_sec_ar(i) = mean(good_ar1(good_one_sec_locs1));
-        
-        if ~isempty(good_one_sec_locs)
-
-            for j = 1:num_bins
-               particle_dist_minR(i,j)  = length(find(good_particle_diameter_minR(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter_minR(good_one_sec_locs) < kk(j+1)));
-               particle_dist_AreaR(i,j) = length(find(good_particle_diameter_AreaR(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter_AreaR(good_one_sec_locs) < kk(j+1)));
-
-               % Create Habit Number Size Distribution 
-               cip2_habitsd(i,j,1) = length(find(good_habit(good_one_sec_locs)=='s' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,2) = length(find(good_habit(good_one_sec_locs)=='l' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,3) = length(find(good_habit(good_one_sec_locs)=='o' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,4) = length(find(good_habit(good_one_sec_locs)=='t' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,5) = length(find(good_habit(good_one_sec_locs)=='h' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,6) = length(find(good_habit(good_one_sec_locs)=='i' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,7) = length(find(good_habit(good_one_sec_locs)=='g' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,8) = length(find(good_habit(good_one_sec_locs)=='d' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,9) = length(find(good_habit(good_one_sec_locs)=='a' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitsd(i,j,10) = length(find(good_habit(good_one_sec_locs)=='I' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-
-               % Create Habit Mass Size Distribution 
-               cip2_habitmsd(i,j,1) = sum(good_iwc(good_habit(good_one_sec_locs)=='s' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,2) = sum(good_iwc(good_habit(good_one_sec_locs)=='l' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,3) = sum(good_iwc(good_habit(good_one_sec_locs)=='o' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,4) = sum(good_iwc(good_habit(good_one_sec_locs)=='t' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,5) = sum(good_iwc(good_habit(good_one_sec_locs)=='h' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,6) = sum(good_iwc(good_habit(good_one_sec_locs)=='i' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,7) = sum(good_iwc(good_habit(good_one_sec_locs)=='g' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,8) = sum(good_iwc(good_habit(good_one_sec_locs)=='d' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,9) = sum(good_iwc(good_habit(good_one_sec_locs)=='a' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               cip2_habitmsd(i,j,10) = sum(good_iwc(good_habit(good_one_sec_locs)=='I' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-
-
-               particle_area(i,j) = nansum(good_area(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-               cip2_meanp(i,j) = nanmean(good_perimeter(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-               if iCreateAspectRatio == 1
-
-               particle_aspectRatio(i,j) = nanmean(good_AspectRatio(good_one_sec_locs1(good_particle_diameter1(good_one_sec_locs1) >= kk(j) &...
-                   good_particle_diameter1(good_one_sec_locs1) < kk(j+1))));
-
-               particle_aspectRatio1(i,j) = nanmean(good_AspectRatio1(good_one_sec_locs1(good_particle_diameter1(good_one_sec_locs1) >= kk(j) &...
-                   good_particle_diameter1(good_one_sec_locs1) < kk(j+1))));
-               end
-               particle_areaRatio1(i,j) = nanmean(good_ar1(good_one_sec_locs1(good_particle_diameter1(good_one_sec_locs1) >= kk(j) &...
-                   good_particle_diameter1(good_one_sec_locs1) < kk(j+1))));
-
-
-               cip2_iwc(i,j) = nansum(good_iwc(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-               cip2_partarea(i,j) = nansum(good_partarea(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-               cip2_iwcbl(i,j) = nansum(good_iwcbl(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-               cip2_vt(i,j) = nansum(good_vt(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-               cip2_pr(i,j) = nansum(good_pr(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                   good_particle_diameter(good_one_sec_locs) < kk(j+1))));
-
-
-               for k = 1:length(area_bins)-1
-                   area_dist2(i,j,k) = length(find(good_ar(good_one_sec_locs) >= area_bins(k) & ...
-                       good_ar(good_one_sec_locs) < area_bins(k+1) & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
-                       good_particle_diameter(good_one_sec_locs) < kk(j+1)));
-               end
-            end
-
-           % Normalize by binwidth and convert from mm to cm
-           particle_dist_minR(i,:)=particle_dist_minR(i,:)./binwidth*10;
-           particle_dist_AreaR(i,:)=particle_dist_AreaR(i,:)./binwidth*10;
-           cip2_iwc(i,:)=cip2_iwc(i,:)./binwidth*10; %g/cm
-           cip2_iwcbl(i,:)=cip2_iwcbl(i,:)./binwidth*10;
-           cip2_vt(i,:)=cip2_vt(i,:)./binwidth*10;
-           cip2_pr(i,:)=cip2_pr(i,:)./binwidth*10;
-           cip2_partarea(i,:)=cip2_partarea(i,:)./binwidth*10;
-           particle_area(i,:)=particle_area(i,:)./binwidth*10;               
-           
-           for mmmmmm=1:10
-               cip2_habitsd(i,:,mmmmmm)=cip2_habitsd(i,:,mmmmmm)./binwidth*10;
-               cip2_habitmsd(i,:,mmmmmm)=cip2_habitmsd(i,:,mmmmmm)./binwidth*10;
-           end
-           
-           for mmmmmm = 1:length(area_bins)-1
-               area_dist2(i,:,mmmmmm) =area_dist2(i,:,mmmmmm)./binwidth*10 ;
-           end
-           
-           % Generalized effective radius calculation from Fu (1996)
-           cip2_re(i) = (sqrt(3)/(3*0.91))*1000*(sum(cip2_iwc(i,:)./binwidth,2)/sum(particle_area(i,:)./binwidth,2))*1000; % in unit of um
-        
-		else
-
-           particle_dist_minR(i,1:num_bins) = 0;
-           particle_dist_AreaR(i,1:num_bins) = 0;
-           area_dist2(i,1:num_bins,1:length(area_bins)-1) = 0;
-           cip2_partarea(i,:) = 0;
-           cip2_iwc(i,:) = 0;
-           cip2_iwcbl(i,:) = 0;
-           cip2_vt(i,:) = 0;
-           cip2_pr(i,:) = 0;
-           cip2_re(i) = 0;
-           cip2_habitsd(i,:,:) = 0;
-           cip2_habitmsd(i,:,:) = 0;
-           time_interval2(i) = 1;
-                     
-           % Legacy: used in Paris intercomparison
-           %{
+			%}
+			
+			
+			if SAmethod==0
+				good_particles = good_particles & centerin==1;
+				if iCreateBad
+					bad_particles = bad_particles & centerin==1;
+				end
+			elseif SAmethod==1
+				good_particles = good_particles & entirein==0;
+				if iCreateBad
+					bad_particles = bad_particles & centerin==0;
+				end
+			end
+			
+			
+			good_partpercent(i)=sum(good_particles)/length(good_particles);
+			
+			rejectpercentbycriterion(i,1)=sum(centerin==1)/length(good_particles);
+			rejectpercentbycriterion(i,2)=sum(auto_reject == '0')/length(good_particles);
+			rejectpercentbycriterion(i,3)=sum(auto_reject == 'H')/length(good_particles);
+			rejectpercentbycriterion(i,4)=sum(auto_reject == 'h')/length(good_particles);
+			rejectpercentbycriterion(i,5)=sum(auto_reject == 'u')/length(good_particles);
+			rejectpercentbycriterion(i,6)=sum(auto_reject == 'a')/length(good_particles);
+			rejectpercentbycriterion(i,7)=sum(auto_reject == 't')/length(good_particles);
+			rejectpercentbycriterion(i,8)=sum(auto_reject == 'p')/length(good_particles);
+			rejectpercentbycriterion(i,9)=sum(auto_reject == 's')/length(good_particles);
+			rejectpercentbycriterion(i,10)=sum(auto_reject == 'z')/length(good_particles);
+			rejectpercentbycriterion(i,11)=sum(auto_reject == 'i')/length(good_particles);
+			rejectpercentbycriterion(i,12)=sum(auto_reject == 'A')/length(good_particles);
+			rejectpercentbycriterion(i,13)=sum(auto_reject == 'S')/length(good_particles); %Shattered - Added DS
+			rejectpercentbycriterion(i,14)=sum(auto_reject == 'R')/length(good_particles); %Reaccepted - Added DS
+			
+			numGoodparticles(i)=length(good_particles);
+			if iCreateBad
+				numBadparticles(i)=length(bad_particles);
+			end
+			
+			%         disp([int32(timehhmmss(i)), sum(good_particles),length(good_particles),length(good_particles)-sum(good_particles)]);
+			
+			image_time = hhmmss2insec(image_time_hhmmss);
+			
+			% Good (accepted) particles
+			good_image_times = image_time(good_particles);
+			good_particle_diameter_minR = particle_diameter_minR(good_particles);
+			good_particle_diameter_AreaR = particle_diameter_AreaR(good_particles);
+			good_int_arr=int_arr(good_particles);
+			good_ar = area_ratio(good_particles);
+			good_area = area(good_particles);
+			good_perimeter = perimeter(good_particles);
+			if iCreateAspectRatio
+				good_AspectRatio = aspectRatio(good_particles & entirein==0);
+				good_AspectRatio1 = aspectRatio1(good_particles & entirein==0);
+			end
+			good_ar1 = area_ratio(good_particles & entirein==0);
+			good_image_times1 = image_time(good_particles  & entirein==0);
+			good_iwc=particle_mass_ice(good_particles);
+			good_lwc=particle_mass_lw(good_particles);
+			good_partarea=calcd_area(good_particles);
+			good_iwcbl=particle_massbl(good_particles);
+			good_vt_ice=particle_vt_ice(good_particles);
+			good_vt_lw=particle_vt_lw(good_particles);
+			good_pr_ice=particle_pr_ice(good_particles);
+			good_pr_lw=particle_pr_lw(good_particles);
+			good_habit=habit1(good_particles);
+			
+			good_particle_diameter=good_particle_diameter_minR;
+			good_particle_diameter1 = particle_diameter_minR(good_particles  & entirein==0);
+			
+			
+			% Bad (rejected) particles
+			if iCreateBad
+				bad_image_times = image_time(bad_particles);
+				bad_particle_diameter_minR = particle_diameter_minR(bad_particles);
+				bad_particle_diameter_AreaR = particle_diameter_AreaR(bad_particles);
+				bad_int_arr=int_arr(bad_particles);
+				bad_ar = area_ratio(bad_particles);
+				bad_area = area(bad_particles);
+				bad_perimeter = perimeter(bad_particles);
+				if iCreateAspectRatio % added if statement if not creating aspect ratio - Joe Finlon - 03/03/17
+					bad_AspectRatio = aspectRatio(bad_particles & entirein==0);
+					bad_AspectRatio1 = aspectRatio1(bad_particles & entirein==0);
+				end
+				bad_ar1 = area_ratio(bad_particles & entirein==0);
+				bad_image_times1 = image_time(bad_particles  & entirein==0);
+				bad_iwc=particle_mass_ice(bad_particles);
+				bad_partarea=calcd_area(bad_particles);
+				bad_iwcbl=particle_massbl(bad_particles);
+				bad_vt=particle_vt_ice(bad_particles);
+				bad_pr=particle_pr_ice(bad_particles);
+				bad_habit=habit1(bad_particles);
+				
+				bad_particle_diameter=bad_particle_diameter_minR;
+				bad_particle_diameter1 = particle_diameter_minR(bad_particles  & entirein==0);
+			end
+			
+			%% Perform various status and error checks
+			if mod(i,1000) == 0
+				fprintf('%d/%d | %s\n',i,one_sec_dur,datestr(now));
+			end
+			
+			total_one_sec_locs(i) = length(find(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)));
+			time_interval2(i) = sum(int_arr(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)));
+			
+			if sum(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)) ~= length(image_time)
+				fprintf(2,'%d / %d\tError on sizing at index %d\n',sum(image_time >= one_sec_times(i) & image_time < one_sec_times(i+1)),length(image_time),i);
+			end
+			
+			if(total_one_sec_locs(i) == 0)
+				time_interval2(i) = 1;
+			end
+			
+			%% Sort good (accepted) particles into size distributions
+			good_one_sec_locs = find(good_image_times >= one_sec_times(i) & good_image_times < one_sec_times(i+1));
+			good_one_sec_locs1 = find(good_image_times1 >= one_sec_times(i) & good_image_times1 < one_sec_times(i+1));
+			
+			goodintpercent(i) = sum(good_int_arr(good_image_times >= one_sec_times(i) & good_image_times < one_sec_times(i+1)))/time_interval2(i);
+			
+			one_sec_ar(i) = mean(good_ar1(good_one_sec_locs1));
+			
+			if ~isempty(good_one_sec_locs)
+				
+				for j = 1:num_bins
+					particle_dist_minR(i,j)  = length(find(good_particle_diameter_minR(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter_minR(good_one_sec_locs) < kk(j+1)));
+					particle_dist_AreaR(i,j) = length(find(good_particle_diameter_AreaR(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter_AreaR(good_one_sec_locs) < kk(j+1)));
+					
+					% Create Habit Number Size Distribution
+					cip2_habitsd(i,j,1) = length(find(good_habit(good_one_sec_locs)=='s' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,2) = length(find(good_habit(good_one_sec_locs)=='l' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,3) = length(find(good_habit(good_one_sec_locs)=='o' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,4) = length(find(good_habit(good_one_sec_locs)=='t' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,5) = length(find(good_habit(good_one_sec_locs)=='h' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,6) = length(find(good_habit(good_one_sec_locs)=='i' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,7) = length(find(good_habit(good_one_sec_locs)=='g' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,8) = length(find(good_habit(good_one_sec_locs)=='d' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,9) = length(find(good_habit(good_one_sec_locs)=='a' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitsd(i,j,10) = length(find(good_habit(good_one_sec_locs)=='I' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					
+					% Create Habit Mass Size Distribution
+					cip2_habitmsd(i,j,1) = sum(good_iwc(good_habit(good_one_sec_locs)=='s' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,2) = sum(good_iwc(good_habit(good_one_sec_locs)=='l' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,3) = sum(good_iwc(good_habit(good_one_sec_locs)=='o' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,4) = sum(good_iwc(good_habit(good_one_sec_locs)=='t' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,5) = sum(good_iwc(good_habit(good_one_sec_locs)=='h' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,6) = sum(good_iwc(good_habit(good_one_sec_locs)=='i' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,7) = sum(good_iwc(good_habit(good_one_sec_locs)=='g' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,8) = sum(good_iwc(good_habit(good_one_sec_locs)=='d' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,9) = sum(good_iwc(good_habit(good_one_sec_locs)=='a' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					cip2_habitmsd(i,j,10) = sum(good_iwc(good_habit(good_one_sec_locs)=='I' & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					
+					
+					particle_area(i,j) = nansum(good_area(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_meanp(i,j) = nanmean(good_perimeter(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					if iCreateAspectRatio
+						particle_aspectRatio(i,j) = nanmean(good_AspectRatio(good_one_sec_locs1(good_particle_diameter1(good_one_sec_locs1) >= kk(j) &...
+							good_particle_diameter1(good_one_sec_locs1) < kk(j+1))));
+						
+						particle_aspectRatio1(i,j) = nanmean(good_AspectRatio1(good_one_sec_locs1(good_particle_diameter1(good_one_sec_locs1) >= kk(j) &...
+							good_particle_diameter1(good_one_sec_locs1) < kk(j+1))));
+					end
+					
+					particle_areaRatio1(i,j) = nanmean(good_ar1(good_one_sec_locs1(good_particle_diameter1(good_one_sec_locs1) >= kk(j) &...
+						good_particle_diameter1(good_one_sec_locs1) < kk(j+1))));
+					
+					
+					cip2_iwc(i,j) = nansum(good_iwc(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_lwc(i,j) = nansum(good_lwc(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_partarea(i,j) = nansum(good_partarea(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_iwcbl(i,j) = nansum(good_iwcbl(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_vt_ice(i,j) = nansum(good_vt_ice(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_vt_lw(i,j) = nansum(good_vt_lw(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_pr_ice(i,j) = nansum(good_pr_ice(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					cip2_pr_lw(i,j) = nansum(good_pr_lw(good_one_sec_locs(good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+						good_particle_diameter(good_one_sec_locs) < kk(j+1))));
+					
+					for k = 1:length(area_bins)-1
+						area_dist2(i,j,k) = length(find(good_ar(good_one_sec_locs) >= area_bins(k) & ...
+							good_ar(good_one_sec_locs) < area_bins(k+1) & good_particle_diameter(good_one_sec_locs) >= kk(j) &...
+							good_particle_diameter(good_one_sec_locs) < kk(j+1)));
+					end
+				end
+				
+				% Normalize by binwidth and convert from mm to cm
+				particle_dist_minR(i,:)=particle_dist_minR(i,:)./binwidth*10;
+				particle_dist_AreaR(i,:)=particle_dist_AreaR(i,:)./binwidth*10;
+				cip2_iwc(i,:)=cip2_iwc(i,:)./binwidth*10; %g/cm
+				cip2_lwc(i,:)=cip2_lwc(i,:)./binwidth*10;
+				cip2_iwcbl(i,:)=cip2_iwcbl(i,:)./binwidth*10;
+				cip2_vt_ice(i,:)=cip2_vt_ice(i,:)./binwidth*10;
+				cip2_vt_lw(i,:)=cip2_vt_lw(i,:)./binwidth*10;
+				cip2_pr_ice(i,:)=cip2_pr_ice(i,:)./binwidth*10;
+				cip2_pr_lw(i,:)=cip2_pr_lw(i,:)./binwidth*10;
+				cip2_partarea(i,:)=cip2_partarea(i,:)./binwidth*10;
+				particle_area(i,:)=particle_area(i,:)./binwidth*10;
+				
+				for mmmmmm=1:10
+					cip2_habitsd(i,:,mmmmmm)=cip2_habitsd(i,:,mmmmmm)./binwidth*10;
+					cip2_habitmsd(i,:,mmmmmm)=cip2_habitmsd(i,:,mmmmmm)./binwidth*10;
+				end
+				
+				for mmmmmm = 1:length(area_bins)-1
+					area_dist2(i,:,mmmmmm) =area_dist2(i,:,mmmmmm)./binwidth*10 ;
+				end
+				
+				% Generalized effective radius calculation from Fu (1996)
+				cip2_re(i) = (sqrt(3)/(3*0.91))*1000*(sum(cip2_iwc(i,:)./binwidth,2)/sum(particle_area(i,:)./binwidth,2))*1000; % in unit of um
+				
+			else
+				
+				particle_dist_minR(i,1:num_bins) = 0;
+				particle_dist_AreaR(i,1:num_bins) = 0;
+				area_dist2(i,1:num_bins,1:length(area_bins)-1) = 0;
+				cip2_partarea(i,:) = 0;
+				cip2_iwc(i,:) = 0;
+				cip2_lwc(i,:) = 0;
+				cip2_iwcbl(i,:) = 0;
+				cip2_vt_ice(i,:) = 0;
+				cip2_vt_lw(i,:) = 0;
+				cip2_pr_ice(i,:) = 0;
+				cip2_pr_lw(i,:) = 0;
+				cip2_re(i) = 0;
+				cip2_habitsd(i,:,:) = 0;
+				cip2_habitmsd(i,:,:) = 0;
+				time_interval2(i) = 1;
+				
+				% Legacy: used in Paris intercomparison
+				%{
            time_interval22(i) = 1;
            time_interval32(i) = 1;
            time_interval42(i) = 1;
            time_interval52(i) = 0;
            time_interval62(i) = 1;
-           %}
-           time_interval72(i) = 0;
-
-           TotalPC1(i)=1;        
-           TotalPC2(i)=1;
-
-        end
-        
-        if iCreateBad == 1
-        %% Sort bad (rejected) particles into size distributions
-        bad_one_sec_locs = find(bad_image_times >= one_sec_times(i) & bad_image_times < one_sec_times(i+1));
-        bad_one_sec_locs1 = find(bad_image_times1 >= one_sec_times(i) & bad_image_times1 < one_sec_times(i+1));
-        
-        badintpercent(i) = sum(bad_int_arr(bad_image_times >= one_sec_times(i) & bad_image_times < one_sec_times(i+1)))/time_interval2(i);
-        
-        bad_one_sec_ar(i) = mean(bad_ar1(bad_one_sec_locs1));
-        
-        if ~isempty(bad_one_sec_locs)
-
-           for j = 1:num_bins
-               bad_particle_dist_minR(i,j)  = length(find(bad_particle_diameter_minR(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter_minR(bad_one_sec_locs) < kk(j+1)));
-               bad_particle_dist_AreaR(i,j) = length(find(bad_particle_diameter_AreaR(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter_AreaR(bad_one_sec_locs) < kk(j+1)));
-
-               % Create Habit Number Size Distribution 
-               bad_cip2_habitsd(i,j,1) = length(find(bad_habit(bad_one_sec_locs)=='s' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,2) = length(find(bad_habit(bad_one_sec_locs)=='l' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,3) = length(find(bad_habit(bad_one_sec_locs)=='o' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,4) = length(find(bad_habit(bad_one_sec_locs)=='t' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,5) = length(find(bad_habit(bad_one_sec_locs)=='h' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,6) = length(find(bad_habit(bad_one_sec_locs)=='i' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,7) = length(find(bad_habit(bad_one_sec_locs)=='g' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,8) = length(find(bad_habit(bad_one_sec_locs)=='d' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,9) = length(find(bad_habit(bad_one_sec_locs)=='a' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitsd(i,j,10) = length(find(bad_habit(bad_one_sec_locs)=='I' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-
-               % Create Habit Mass Size Distribution 
-               bad_cip2_habitmsd(i,j,1) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='s' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,2) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='l' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,3) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='o' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,4) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='t' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,5) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='h' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,6) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='i' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,7) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='g' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,8) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='d' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,9) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='a' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               bad_cip2_habitmsd(i,j,10) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='I' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-
-
-               bad_particle_area(i,j) = nansum(bad_area(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-               bad_cip2_meanp(i,j) = nanmean(bad_perimeter(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-               if iCreateAspectRatio == 1 % added if statement if not creating aspect ratio - Joe Finlon - 03/03/17
-               bad_particle_aspectRatio(i,j) = nanmean(bad_AspectRatio(bad_one_sec_locs1(bad_particle_diameter1(bad_one_sec_locs1) >= kk(j) &...
-                   bad_particle_diameter1(bad_one_sec_locs1) < kk(j+1))));
-
-               bad_particle_aspectRatio1(i,j) = nanmean(bad_AspectRatio1(bad_one_sec_locs1(bad_particle_diameter1(bad_one_sec_locs1) >= kk(j) &...
-                   bad_particle_diameter1(bad_one_sec_locs1) < kk(j+1))));
-               end
-
-               bad_particle_areaRatio1(i,j) = nanmean(bad_ar1(bad_one_sec_locs1(bad_particle_diameter1(bad_one_sec_locs1) >= kk(j) &...
-                   bad_particle_diameter1(bad_one_sec_locs1) < kk(j+1))));
-
-
-               bad_cip2_iwc(i,j) = nansum(bad_iwc(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-               bad_cip2_partarea(i,j) = nansum(bad_partarea(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-               bad_cip2_iwcbl(i,j) = nansum(bad_iwcbl(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-               bad_cip2_vt(i,j) = nansum(bad_vt(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-               bad_cip2_pr(i,j) = nansum(bad_pr(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                   bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
-
-
-               for k = 1:length(area_bins)-1
-                   bad_area_dist2(i,j,k) = length(find(bad_ar(bad_one_sec_locs) >= area_bins(k) & ...
-                       bad_ar(bad_one_sec_locs) < area_bins(k+1) & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
-                       bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
-               end
-           end
-
-           % Normalize by binwidth and convert from mm to cm
-           bad_particle_dist_minR(i,:)=bad_particle_dist_minR(i,:)./binwidth*10;
-           bad_particle_dist_AreaR(i,:)=bad_particle_dist_AreaR(i,:)./binwidth*10;
-           bad_cip2_iwc(i,:)=bad_cip2_iwc(i,:)./binwidth*10; %g/cm
-           bad_cip2_iwcbl(i,:)=bad_cip2_iwcbl(i,:)./binwidth*10;
-           bad_cip2_vt(i,:)=bad_cip2_vt(i,:)./binwidth*10;
-           bad_cip2_pr(i,:)=bad_cip2_pr(i,:)./binwidth*10;
-           bad_cip2_partarea(i,:)=bad_cip2_partarea(i,:)./binwidth*10;
-           bad_particle_area(i,:)=bad_particle_area(i,:)./binwidth*10;               
-           
-           for mmmmmm=1:10
-               bad_cip2_habitsd(i,:,mmmmmm)=bad_cip2_habitsd(i,:,mmmmmm)./binwidth*10;
-               bad_cip2_habitmsd(i,:,mmmmmm)=bad_cip2_habitmsd(i,:,mmmmmm)./binwidth*10;
-           end
-           
-           for mmmmmm = 1:length(area_bins)-1
-               bad_area_dist2(i,:,mmmmmm)=bad_area_dist2(i,:,mmmmmm)./binwidth*10 ;
-           end
-           
-           % Generalized effective radius calculation from Fu (1996)
-           bad_cip2_re(i) = (sqrt(3)/(3*0.91))*1000*(sum(bad_cip2_iwc(i,:)./binwidth,2)/sum(bad_particle_area(i,:)./binwidth,2))*1000; % in unit of um
-        
-        else
-           bad_particle_dist_minR(i,1:num_bins) = 0;
-           bad_particle_dist_AreaR(i,1:num_bins) = 0;
-           bad_area_dist2(i,1:num_bins,1:length(area_bins)-1) = 0;
-           bad_cip2_partarea(i,:) = 0;
-           bad_cip2_iwc(i,:) = 0;
-           bad_cip2_iwcbl(i,:) = 0;
-           bad_cip2_vt(i,:) = 0;
-           bad_cip2_pr(i,:) = 0;
-           bad_cip2_re(i) = 0;
-           bad_cip2_habitsd(i,:,:) = 0;
-           bad_cip2_habitmsd(i,:,:) = 0;
-
-        end
-        end
-        warning on all
-%     elseif (int32(timehhmmss(i))<int32(starttime(jjj)))
-    elseif (eofFlag==1 || int32(timehhmmss(i))<int32(starttime(jjj))) % Modified by Joe Finlon - 03/03/17
-
-       particle_dist_minR(i,1:num_bins) = NaN;
-       particle_dist_AreaR(i,1:num_bins) = NaN;
-       area_dist2(i,1:num_bins,1:length(area_bins)-1) = NaN;
-       cip2_partarea(i,:) = NaN;
-       cip2_iwc(i,:) = NaN;
-       cip2_iwcbl(i,:) = NaN;
-       cip2_vt(i,:) = NaN;
-       cip2_pr(i,:) = NaN;
-       cip2_re(i) = NaN;
-       cip2_habitsd(i,:,:) = NaN;
-       cip2_habitmsd(i,:,:) = NaN;
-       one_sec_ar(i) = NaN;
-       good_partpercent(i)=1;
-       rejectpercentbycriterion(i,:)=NaN;
-       numGoodparticles(i)=NaN;
-       time_interval2(i) = 1;
-       
-       % Legacy: used in Paris intercomparison
-       %{
+				%}
+				time_interval72(i) = 0;
+				
+				TotalPC1(i)=1;
+				TotalPC2(i)=1;
+				
+			end
+			
+			
+			%% Sort bad (rejected) particles into size distributions
+			if iCreateBad
+				bad_one_sec_locs = find(bad_image_times >= one_sec_times(i) & bad_image_times < one_sec_times(i+1));
+				bad_one_sec_locs1 = find(bad_image_times1 >= one_sec_times(i) & bad_image_times1 < one_sec_times(i+1));
+				
+				badintpercent(i) = sum(bad_int_arr(bad_image_times >= one_sec_times(i) & bad_image_times < one_sec_times(i+1)))/time_interval2(i);
+				
+				bad_one_sec_ar(i) = mean(bad_ar1(bad_one_sec_locs1));
+				
+				if ~isempty(bad_one_sec_locs)
+					
+					for j = 1:num_bins
+						bad_particle_dist_minR(i,j)  = length(find(bad_particle_diameter_minR(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter_minR(bad_one_sec_locs) < kk(j+1)));
+						bad_particle_dist_AreaR(i,j) = length(find(bad_particle_diameter_AreaR(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter_AreaR(bad_one_sec_locs) < kk(j+1)));
+						
+						% Create Habit Number Size Distribution
+						bad_cip2_habitsd(i,j,1) = length(find(bad_habit(bad_one_sec_locs)=='s' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,2) = length(find(bad_habit(bad_one_sec_locs)=='l' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,3) = length(find(bad_habit(bad_one_sec_locs)=='o' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,4) = length(find(bad_habit(bad_one_sec_locs)=='t' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,5) = length(find(bad_habit(bad_one_sec_locs)=='h' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,6) = length(find(bad_habit(bad_one_sec_locs)=='i' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,7) = length(find(bad_habit(bad_one_sec_locs)=='g' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,8) = length(find(bad_habit(bad_one_sec_locs)=='d' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,9) = length(find(bad_habit(bad_one_sec_locs)=='a' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitsd(i,j,10) = length(find(bad_habit(bad_one_sec_locs)=='I' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						
+						% Create Habit Mass Size Distribution
+						bad_cip2_habitmsd(i,j,1) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='s' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,2) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='l' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,3) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='o' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,4) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='t' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,5) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='h' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,6) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='i' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,7) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='g' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,8) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='d' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,9) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='a' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						bad_cip2_habitmsd(i,j,10) = sum(bad_iwc(bad_habit(bad_one_sec_locs)=='I' & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						
+						
+						bad_particle_area(i,j) = nansum(bad_area(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						bad_cip2_meanp(i,j) = nanmean(bad_perimeter(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						if iCreateAspectRatio
+							bad_particle_aspectRatio(i,j) = nanmean(bad_AspectRatio(bad_one_sec_locs1(bad_particle_diameter1(bad_one_sec_locs1) >= kk(j) &...
+								bad_particle_diameter1(bad_one_sec_locs1) < kk(j+1))));
+							
+							bad_particle_aspectRatio1(i,j) = nanmean(bad_AspectRatio1(bad_one_sec_locs1(bad_particle_diameter1(bad_one_sec_locs1) >= kk(j) &...
+								bad_particle_diameter1(bad_one_sec_locs1) < kk(j+1))));
+						end
+						
+						bad_particle_areaRatio1(i,j) = nanmean(bad_ar1(bad_one_sec_locs1(bad_particle_diameter1(bad_one_sec_locs1) >= kk(j) &...
+							bad_particle_diameter1(bad_one_sec_locs1) < kk(j+1))));
+						
+						
+						bad_cip2_iwc(i,j) = nansum(bad_iwc(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						bad_cip2_partarea(i,j) = nansum(bad_partarea(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						bad_cip2_iwcbl(i,j) = nansum(bad_iwcbl(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						bad_cip2_vt(i,j) = nansum(bad_vt(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						bad_cip2_pr(i,j) = nansum(bad_pr(bad_one_sec_locs(bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+							bad_particle_diameter(bad_one_sec_locs) < kk(j+1))));
+						
+						
+						for k = 1:length(area_bins)-1
+							bad_area_dist2(i,j,k) = length(find(bad_ar(bad_one_sec_locs) >= area_bins(k) & ...
+								bad_ar(bad_one_sec_locs) < area_bins(k+1) & bad_particle_diameter(bad_one_sec_locs) >= kk(j) &...
+								bad_particle_diameter(bad_one_sec_locs) < kk(j+1)));
+						end
+					end
+					
+					% Normalize by binwidth and convert from mm to cm
+					bad_particle_dist_minR(i,:)=bad_particle_dist_minR(i,:)./binwidth*10;
+					bad_particle_dist_AreaR(i,:)=bad_particle_dist_AreaR(i,:)./binwidth*10;
+					bad_cip2_iwc(i,:)=bad_cip2_iwc(i,:)./binwidth*10; %g/cm
+					bad_cip2_iwcbl(i,:)=bad_cip2_iwcbl(i,:)./binwidth*10;
+					bad_cip2_vt(i,:)=bad_cip2_vt(i,:)./binwidth*10;
+					bad_cip2_pr(i,:)=bad_cip2_pr(i,:)./binwidth*10;
+					bad_cip2_partarea(i,:)=bad_cip2_partarea(i,:)./binwidth*10;
+					bad_particle_area(i,:)=bad_particle_area(i,:)./binwidth*10;
+					
+					for mmmmmm=1:10
+						bad_cip2_habitsd(i,:,mmmmmm)=bad_cip2_habitsd(i,:,mmmmmm)./binwidth*10;
+						bad_cip2_habitmsd(i,:,mmmmmm)=bad_cip2_habitmsd(i,:,mmmmmm)./binwidth*10;
+					end
+					
+					for mmmmmm = 1:length(area_bins)-1
+						bad_area_dist2(i,:,mmmmmm)=bad_area_dist2(i,:,mmmmmm)./binwidth*10 ;
+					end
+					
+					% Generalized effective radius calculation from Fu (1996)
+					bad_cip2_re(i) = (sqrt(3)/(3*0.91))*1000*(sum(bad_cip2_iwc(i,:)./binwidth,2)/sum(bad_particle_area(i,:)./binwidth,2))*1000; % in unit of um
+					
+				else
+					bad_particle_dist_minR(i,1:num_bins) = 0;
+					bad_particle_dist_AreaR(i,1:num_bins) = 0;
+					bad_area_dist2(i,1:num_bins,1:length(area_bins)-1) = 0;
+					bad_cip2_partarea(i,:) = 0;
+					bad_cip2_iwc(i,:) = 0;
+					bad_cip2_iwcbl(i,:) = 0;
+					bad_cip2_vt(i,:) = 0;
+					bad_cip2_pr(i,:) = 0;
+					bad_cip2_re(i) = 0;
+					bad_cip2_habitsd(i,:,:) = 0;
+					bad_cip2_habitmsd(i,:,:) = 0;
+					
+				end
+			end
+			
+			warning on all
+		%     elseif (int32(timehhmmss(i))<int32(starttime(jjj)))
+        elseif (eofFlag==1 || int32(timehhmmss(i))<int32(starttime(jjj))) % Modified by Joe Finlon - 03/03/17
+			
+			particle_dist_minR(i,1:num_bins) = NaN;
+			particle_dist_AreaR(i,1:num_bins) = NaN;
+			area_dist2(i,1:num_bins,1:length(area_bins)-1) = NaN;
+			cip2_partarea(i,:) = NaN;
+			cip2_iwc(i,:) = NaN;
+			cip2_lwc(i,:) = NaN;
+			cip2_iwcbl(i,:) = NaN;
+			cip2_vt_ice(i,:) = NaN;
+			cip2_vt_lw(i,:) = NaN;
+			cip2_pr_ice(i,:) = NaN;
+			cip2_pr_lw(i,:) = NaN;
+			cip2_re(i) = NaN;
+			cip2_habitsd(i,:,:) = NaN;
+			cip2_habitmsd(i,:,:) = NaN;
+			one_sec_ar(i) = NaN;
+			good_partpercent(i)=1;
+			rejectpercentbycriterion(i,:)=NaN;
+			numGoodparticles(i)=NaN;
+			time_interval2(i) = 1;
+			
+			% Legacy: used in Paris intercomparison
+			%{
        time_interval22(i) = 1;
        time_interval32(i) = 1;
-       time_interval42(i) = 1;    
-       time_interval52(i) = 0;    
-       time_interval62(i) = 1;       
-       %}
-       time_interval72(i) = 0;
-       
-       TotalPC1(i)=1;        
-       TotalPC2(i)=1;
-       
-    end
-
-end
-
-% Finished Sorting and close input file.
-netcdf.close(f);
-
-fprintf('int_arr > 1 mean: %.4f, max: %.4f\nNumber of particles with int_arr > 1: %d\n\n',...
-	mean(intArrGT1),max(intArrGT1),sumIntArrGT1);
-
-fprintf('Size distribution calculations and sorting completed %s\n\n', datestr(now));
-
-
-%% Check TAS length, should be the same
-% if (jjj~=length(start_all))
-%     disp([jjj, length(start_all)])
-%     %error('Watch Out for less TAS time at the end!')
-% end
-
-%disp([num2str(100*nThrow11/maxRecNum),'% is thrown out IN TOTAL']); 
-
-%% Combine - calculate sample volumes, and divide by sample volumes 
-% Modified by Will, Nov 27th, 2013. For flexible bins
-cip2_binmin = kk(1:end-1); 
-cip2_binmax = kk(2:end); 
-cip2_binmid = (cip2_binmin+cip2_binmax)/2; 
-cip2_bindD = diff(kk);
-
-% Legacy bin and surface area calculations
-%{
+       time_interval42(i) = 1;
+       time_interval52(i) = 0;
+       time_interval62(i) = 1;
+			%}
+			time_interval72(i) = 0;
+			
+			TotalPC1(i)=1;
+			TotalPC2(i)=1;
+			
+		end
+		
+	end
+	
+	% Finished Sorting and close input file.
+	netcdf.close(f);
+	
+	fprintf('int_arr > 1 mean: %.4f, max: %.4f\nNumber of particles with int_arr > 1: %d\n\n',...
+		mean(intArrGT1),max(intArrGT1),sumIntArrGT1);
+	
+	fprintf('Size distribution calculations and sorting completed %s\n\n', datestr(now));
+	
+	
+	%% Check TAS length, should be the same
+	% if (jjj~=length(start_all))
+	%     disp([jjj, length(start_all)])
+	%     %error('Watch Out for less TAS time at the end!')
+	% end
+	
+	%disp([num2str(100*nThrow11/maxRecNum),'% is thrown out IN TOTAL']);
+	
+	%% Combine - calculate sample volumes, and divide by sample volumes
+	% Modified by Will, Nov 27th, 2013. For flexible bins
+	cip2_binmin = kk(1:end-1);
+	cip2_binmax = kk(2:end);
+	cip2_binmid = (cip2_binmin+cip2_binmax)/2;
+	cip2_bindD = diff(kk);
+	
+	% Legacy bin and surface area calculations
+	%{
 % cip2_binmin = diodesize/2:diodesize:(num_bins-0.5)*diodesize; %(12.5:25:(num_bins-0.5)*25);
 % cip2_binmax = 3*diodesize/2:diodesize:(num_bins+0.5)*diodesize; %(37.5:25:(num_bins+0.5)*25);
 % cip2_binmid = diodesize:diodesize:num_bins*diodesize; %(25:25:num_bins*25);
@@ -1540,461 +1623,499 @@ cip2_bindD = diff(kk);
 %     case '2DS'
 %         sa2 = calc_sa_randombins(cip2_binmid,res,armdst,num_diodes, SAmethod); %(bins_mid,res,armdst,num_diodes)
 % end
-%}
-
-sa2 = calc_sa_randombins(cip2_binmid,res,armdst,num_diodes,SAmethod, probetype); %(bins_mid,res,armdst,num_diodes)
-
-% Clocking problem correction
-vol_scale_factor = tas/tasMax;  
-vol_scale_factor(vol_scale_factor < 1) = 1;
-
-TotalPC2_pre = TotalPC2;
-
-if probetype==2
-    time_interval200=1-time_interval72';
-
-elseif probetype==1
-	% Correct offset in probe particle count (TotalPC2) when we have negative values
-    TotalPC2(TotalPC2<0)=TotalPC2(TotalPC2<0)+2^16;
+	%}
 	
-	% Derive a linear scale factor based on the difference between number of images (TotalPC1)
-	% and number of particles counted by the probe (TotalPC2).
-    time_interval199=(TotalPC1./TotalPC2)';
-
-elseif 0==probetype
-    time_interval200=1-time_interval72';
-end
-
-% Experimental - Use with care!
-% It was discovered that for data collected during the PECAN project, there were quite
-% a few periods of time when the number of images we had for a 1-sec period of time was
-% up to twice that of the number of particles the probe counted.
-% This next if-statement contains code to find and change these instances to 1, resolving 
-% the far exaggerated concentrations that resulted otherwise.
-if probetype==1
-	TotalPCerrIx = find(time_interval199 > 1);
-	time_interval200 = time_interval199;
-	time_interval200(TotalPCerrIx) = 1;
-    fprintf(['Total image count exceeded probe particle count %d times\ntime_interval200',...
-        ' was set to 1 in these cases. See TotalPCerrIx variable for indices of occurence.\n\n'],...
-        length(TotalPCerrIx)); % moved inside if statement - Joe Finlon - 03/03/17
-end
-
-for j=1:num_bins
-    % Sample volume is in m-3
-%     svol_old(j,:)=dof/100.*sa/100.*tas;
-    svol2(j,:) = sa2(j)*(1e-3)^2*time_interval200.*tas; %m3 .*vol_scale_factor
-end
-
-svol2 = svol2*100^3; %cm3
-
-for j = 1:10
-    svol2a(:,:,j) = svol2';
-end
-
-% Good (accepted) particles
-cip2_conc_minR  = particle_dist_minR./svol2';
-cip2_conc_AreaR = particle_dist_AreaR./svol2';
-cip2_area = particle_area./svol2';
-cip2_partarea = cip2_partarea./svol2';
-cip2_iwc = cip2_iwc./svol2';
-cip2_iwcbl = cip2_iwcbl./svol2';
-cip2_vt = cip2_vt./svol2';
-cip2_pr = cip2_pr./svol2';
-
-cip2_countP_no  = particle_dist_minR.*repmat(binwidth,[length(tas) 1])/10; % un-normalized by binwitdh - Joe Finlon - 03/03/17
-cip2_conc_areaDist = permute(double(area_dist2)./svol2a, [3 2 1]);
-cip2_n = nansum(cip2_conc_minR.*repmat(binwidth,[length(tas) 1]),2)/10; % un-normalized by binwitdh & converted to cm^-3 - Joe Finlon - 03/03/17
-cip2_lwc = lwc_calc(cip2_conc_minR,cip2_binmid);
-
-% Bad (rejected) particles
-bad_cip2_conc_minR  = bad_particle_dist_minR./svol2';
-bad_cip2_conc_AreaR = bad_particle_dist_AreaR./svol2';
-bad_cip2_area = bad_particle_area./svol2';
-bad_cip2_partarea = bad_cip2_partarea./svol2';
-bad_cip2_iwc = bad_cip2_iwc./svol2';
-bad_cip2_iwcbl = bad_cip2_iwcbl./svol2';
-bad_cip2_vt = bad_cip2_vt./svol2';
-bad_cip2_pr = bad_cip2_pr./svol2';
-
-bad_cip2_countP_no  = bad_particle_dist_minR.*repmat(binwidth,[length(tas) 1])/10; % un-normalized by binwitdh - Joe Finlon - 03/03/17
-bad_cip2_conc_areaDist = permute(double(bad_area_dist2)./svol2a, [3 2 1]);
-bad_cip2_n = nansum(bad_cip2_conc_minR.*repmat(binwidth,[length(tas) 1]),2)/10; % un-normalized by binwitdh & converted to cm^-3 - Joe Finlon - 03/03/17
-bad_cip2_lwc = lwc_calc(bad_cip2_conc_minR,cip2_binmid);
-
-
-
-%% Output results into NETCDF files (mainf)
-
-fprintf('Now writing output files %s\n\n',datestr(now));
-
-if applyIntArrThresh
-	save([outfile(1:end-3) 'noShatters.mat']);
-else
-	save([outfile(1:end-3) 'withShatters.mat']);
-end
-
-
-% Define Dimensions
-dimid0 = netcdf.defDim(mainf,'CIPcorrlen',num_bins);
-dimid1 = netcdf.defDim(mainf,'CIParealen',10);
-dimid2 = netcdf.defDim(mainf,'Time',length(timehhmmss));
-dimid3 = netcdf.defDim(mainf,'Habit',10);
-
-% Define Global Attributes
-NC_GLOBAL = netcdf.getConstant('NC_GLOBAL');
-netcdf.putAtt(mainf, NC_GLOBAL, 'Software', 'UIOPS/sizeDist');
-netcdf.putAtt(mainf, NC_GLOBAL, 'Institution', 'Univ. Illinois, Dept. Atmos. Sciences');
-netcdf.putAtt(mainf, NC_GLOBAL, 'Creation Time', datestr(now, 'yyyy/mm/dd HH:MM:SS'));
-netcdf.putAtt(mainf, NC_GLOBAL, 'Description', ['Contains size distributions of ',...
-    'particle count, mass, etc. & various bulk properties.']);
-netcdf.putAtt(mainf, NC_GLOBAL, 'Project', projectname);
-netcdf.putAtt(mainf, NC_GLOBAL, 'Data Source', infile);
-netcdf.putAtt(mainf, NC_GLOBAL, 'Probe Type', probename);
-if SAmethod==0
-    netcdf.putAtt(mainf, NC_GLOBAL, 'SA Method', 'Center-in');
-elseif SAmethod==1
-    netcdf.putAtt(mainf, NC_GLOBAL, 'SA Method', 'Entire-in');
-elseif SAmethod==2
-    netcdf.putAtt(mainf, NC_GLOBAL, 'SA Method', 'Using Heymsfield & Parrish (1978) correction');
-end
-if d_choice==1
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'L_x');
-elseif d_choice==2
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'L_y');
-elseif d_choice==3
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'mean(L_x,L_y)');
-elseif d_choice==4
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'hypotenuse(L_x,L_y)');
-elseif d_choice==5
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'max(L_x,L_y)');
-elseif d_choice==6
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'D of minimum enclosing circle');
-end
-if applyIntArrThresh && reaccptShatrs
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Shattering Algorithm',...
-        'Applied w/ reacceptance of particles');
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Reacceptance Criteria',...
-        ['D > ', num2str(reaccptD*1000), ' um; inter-arrival < ',...
-        num2str(reaccptMaxIA), ' sec'])
-elseif applyIntArrThresh && ~reaccptShatrs
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Shattering Algorithm',...
-        'Applied without reacceptance of particles');
-else
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Shattering Algorithm', 'Not applied');
-end
-if iCreateBad && iCreateAspectRatio && iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'SDs from rejected particles, SDs w/ aspect ratio, Sample volume info');
-elseif iCreateBad && ~iCreateAspectRatio && iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'SDs from rejected particles, Sample volume info');
-elseif iCreateBad && iCreateAspectRatio && ~iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'SDs from rejected particles, SDs w/ aspect ratio');
-elseif iCreateBad && ~iCreateAspectRatio && ~iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'SDs from rejected particles');
-elseif ~iCreateBad && iCreateAspectRatio && iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'SDs w/ aspect ratio, Sample volume info');
-elseif ~iCreateBad && ~iCreateAspectRatio && iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'Sample volume info');
-elseif ~iCreateBad && iCreateAspectRatio && ~iSaveIntArrSV
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
-        'SDs w/ aspect ratio');
-else
-    netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved', 'None');
-end
-
-% Define Variables
-varid0 = netcdf.defVar(mainf,'time','double',dimid2); 
-netcdf.putAtt(mainf, varid0,'units','HHMMSS');
-netcdf.putAtt(mainf, varid0,'name','Time');
-
-varid1 = netcdf.defVar(mainf,'bin_min','double',dimid0); 
-netcdf.putAtt(mainf, varid1,'units','millimeter');
-netcdf.putAtt(mainf, varid1,'long_name','bin minimum size');
-netcdf.putAtt(mainf, varid1,'short_name','bin min');
-
-varid2 = netcdf.defVar(mainf,'bin_max','double',dimid0); 
-netcdf.putAtt(mainf, varid2,'units','millimeter');
-netcdf.putAtt(mainf, varid2,'long_name','bin maximum size');
-netcdf.putAtt(mainf, varid2,'short_name','bin max');
-
-varid3 = netcdf.defVar(mainf,'bin_mid','double',dimid0); 
-netcdf.putAtt(mainf, varid3,'units','millimeter');
-netcdf.putAtt(mainf, varid3,'long_name','bin midpoint size');
-netcdf.putAtt(mainf, varid3,'short_name','bin mid');
-
-varid4 = netcdf.defVar(mainf,'bin_dD','double',dimid0); 
-netcdf.putAtt(mainf, varid4,'units','millimeter');
-netcdf.putAtt(mainf, varid4,'long_name','bin size');
-netcdf.putAtt(mainf, varid4,'short_name','bin size');
-
-% Good (accepted) particles
-varid5 = netcdf.defVar(mainf,'conc_minR','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid5,'units','cm-4');
-netcdf.putAtt(mainf, varid5,'long_name','Size distribution using Dmax');
-netcdf.putAtt(mainf, varid5,'short_name','N(Dmax)');
-
-varid6 = netcdf.defVar(mainf,'area','double',[dimid1 dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid6,'units','cm-4');
-netcdf.putAtt(mainf, varid6,'long_name','binned area ratio');
-netcdf.putAtt(mainf, varid6,'short_name','binned area ratio');
-
-varid7 = netcdf.defVar(mainf,'conc_AreaR','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid7,'units','cm-4');
-netcdf.putAtt(mainf, varid7,'long_name','Size distribution using area-equivalent Diameter');
-netcdf.putAtt(mainf, varid7,'short_name','N(Darea)');
-
-varid8 = netcdf.defVar(mainf,'n','double',dimid2); 
-netcdf.putAtt(mainf, varid8,'units','cm-3');
-netcdf.putAtt(mainf, varid8,'long_name','number concentration');
-netcdf.putAtt(mainf, varid8,'short_name','N');
-
-varid9 = netcdf.defVar(mainf,'total_area','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid9,'units','mm2/cm4');
-netcdf.putAtt(mainf, varid9,'long_name','projected area (extinction)');
-netcdf.putAtt(mainf, varid9,'short_name','Ac');
-
-varid10 = netcdf.defVar(mainf,'mass','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid10,'units','g/cm4');
-netcdf.putAtt(mainf, varid10,'long_name','mass using m-D relations');
-netcdf.putAtt(mainf, varid10,'short_name','mass');
-
-varid11 = netcdf.defVar(mainf,'habitsd','double',[dimid3 dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid11,'units','cm-4');
-netcdf.putAtt(mainf, varid11,'long_name','Size Distribution with Habit');
-netcdf.putAtt(mainf, varid11,'short_name','habit SD');
-
-varid12 = netcdf.defVar(mainf,'re','double',dimid2); 
-netcdf.putAtt(mainf, varid12,'units','mm');
-netcdf.putAtt(mainf, varid12,'long_name','effective radius');
-netcdf.putAtt(mainf, varid12,'short_name','Re');
-
-varid13 = netcdf.defVar(mainf,'ar','double',dimid2); 
-netcdf.putAtt(mainf, varid13,'units','100/100');
-netcdf.putAtt(mainf, varid13,'long_name','Area Ratio');
-netcdf.putAtt(mainf, varid13,'short_name','AR');
-
-varid14 = netcdf.defVar(mainf,'massBL','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid14,'units','g/cm4');
-netcdf.putAtt(mainf, varid14,'long_name','mass using Baker and Lawson method');
-netcdf.putAtt(mainf, varid14,'short_name','mass_BL');
-
-varid15 = netcdf.defVar(mainf,'Reject_ratio','double',dimid2); 
-netcdf.putAtt(mainf, varid15,'units','100/100');
-netcdf.putAtt(mainf, varid15,'long_name','Reject Ratio');
-
-varid16 = netcdf.defVar(mainf,'vt','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid16,'units','g/cm4');
-netcdf.putAtt(mainf, varid16,'long_name','Mass-weighted terminal velocity');
-
-varid17 = netcdf.defVar(mainf,'Prec_rate','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid17,'units','mm/hr');
-netcdf.putAtt(mainf, varid17,'long_name','Precipitation Rate');
-
-varid18 = netcdf.defVar(mainf,'habitmsd','double',[dimid3 dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid18,'units','g/cm-4');
-netcdf.putAtt(mainf, varid18,'long_name','Mass Size Distribution with Habit');
-netcdf.putAtt(mainf, varid18,'short_name','Habit Mass SD');
-
-varid19 = netcdf.defVar(mainf,'Calcd_area','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid19,'units','mm^2/cm4');
-netcdf.putAtt(mainf, varid19,'long_name','Particle Area Calculated using A-D realtions');
-netcdf.putAtt(mainf, varid19,'short_name','Ac_calc');
-
-varid20 = netcdf.defVar(mainf,'count','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid20,'units','1');
-netcdf.putAtt(mainf, varid20,'long_name','number count for partial images without any correction');
-
-if iCreateAspectRatio == 1
-varid21 = netcdf.defVar(mainf,'mean_aspect_ratio_rectangle','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid21,'units','1');
-netcdf.putAtt(mainf, varid21,'long_name','Aspect Ratio by Rectangle fit');
-
-varid22 = netcdf.defVar(mainf,'mean_aspect_ratio_ellipse','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid22,'units','1');
-netcdf.putAtt(mainf, varid22,'long_name','Aspect Ratio by Ellipse fit');
-end
-varid23 = netcdf.defVar(mainf,'mean_area_ratio','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid23,'units','1');
-netcdf.putAtt(mainf, varid23,'long_name','Area Ratio');
-
-varid24 = netcdf.defVar(mainf,'mean_perimeter','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid24,'units','um');
-netcdf.putAtt(mainf, varid24,'long_name','mean perimeter');
-
-if iCreateBad == 1
-
-% Bad (rejected) particles
-varid25 = netcdf.defVar(mainf,'REJ_conc_minR','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid25,'units','cm-4');
-netcdf.putAtt(mainf, varid25,'long_name','Size distribution of rejected particles using Dmax');
-netcdf.putAtt(mainf, varid25,'short_name','N(Dmax) rejected');
-
-varid26 = netcdf.defVar(mainf,'REJ_area','double',[dimid1 dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid26,'units','cm-4');
-netcdf.putAtt(mainf, varid26,'long_name','binned area ratio of rejected particles');
-netcdf.putAtt(mainf, varid26,'short_name','binned area ratio of rejected particles');
-
-varid27 = netcdf.defVar(mainf,'REJ_conc_AreaR','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid27,'units','cm-4');
-netcdf.putAtt(mainf, varid27,'long_name','Size distribution of rejected particles using area-equivalent Diameter');
-netcdf.putAtt(mainf, varid27,'short_name','N(Darea) rejected');
-
-varid28 = netcdf.defVar(mainf,'REJ_n','double',dimid2); 
-netcdf.putAtt(mainf, varid28,'units','cm-3');
-netcdf.putAtt(mainf, varid28,'long_name','number concentration of rejected particles');
-netcdf.putAtt(mainf, varid28,'short_name','N_rejected');
-
-varid29 = netcdf.defVar(mainf,'REJ_total_area','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid29,'units','mm2/cm4');
-netcdf.putAtt(mainf, varid29,'long_name','projected area (extinction) of rejected particles');
-netcdf.putAtt(mainf, varid29,'short_name','Ac_rejected');
-
-varid30 = netcdf.defVar(mainf,'REJ_mass','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid30,'units','g/cm4');
-netcdf.putAtt(mainf, varid30,'long_name','mass of rejected particles using m-D relations');
-netcdf.putAtt(mainf, varid30,'short_name','mass_rejected');
-
-varid31 = netcdf.defVar(mainf,'REJ_habitsd','double',[dimid3 dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid31,'units','cm-4');
-netcdf.putAtt(mainf, varid31,'long_name','Size Distribution with Habit of rejected particles');
-netcdf.putAtt(mainf, varid31,'short_name','habit SD rejected');
-
-varid32 = netcdf.defVar(mainf,'REJ_re','double',dimid2); 
-netcdf.putAtt(mainf, varid32,'units','mm');
-netcdf.putAtt(mainf, varid32,'long_name','effective radius of rejected particles');
-netcdf.putAtt(mainf, varid32,'short_name','Re_rejected');
-
-varid33 = netcdf.defVar(mainf,'REJ_ar','double',dimid2); 
-netcdf.putAtt(mainf, varid33,'units','100/100');
-netcdf.putAtt(mainf, varid33,'long_name','Area Ratio of rejected particles');
-netcdf.putAtt(mainf, varid33,'short_name','AR_rejected');
-
-varid34 = netcdf.defVar(mainf,'REJ_massBL','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid34,'units','g/cm4');
-netcdf.putAtt(mainf, varid34,'long_name','mass of rejected particles using Baker and Lawson method');
-netcdf.putAtt(mainf, varid34,'short_name','mass_BL_rejected');
-
-varid35 = netcdf.defVar(mainf,'REJ_vt','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid35,'units','g/cm4');
-netcdf.putAtt(mainf, varid35,'long_name','Mass-weighted terminal velocity of rejected particles');
-
-varid36 = netcdf.defVar(mainf,'REJ_Prec_rate','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid36,'units','mm/hr');
-netcdf.putAtt(mainf, varid36,'long_name','Precipitation Rate of rejected particles');
-
-varid37 = netcdf.defVar(mainf,'REJ_habitmsd','double',[dimid3 dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid37,'units','g/cm-4');
-netcdf.putAtt(mainf, varid37,'long_name','Mass Size Distribution with Habit of rejected particles');
-netcdf.putAtt(mainf, varid37,'short_name','Habit Mass SD rejected');
-
-varid38 = netcdf.defVar(mainf,'REJ_Calcd_area','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid38,'units','mm^2/cm4');
-netcdf.putAtt(mainf, varid38,'long_name','Particle Area of rejected particles Calculated using A-D realtions');
-netcdf.putAtt(mainf, varid38,'short_name','Ac_calc_rejected');
-
-varid39 = netcdf.defVar(mainf,'REJ_count','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid39,'units','1');
-netcdf.putAtt(mainf, varid39,'long_name','number count of rejected particles for partial images without any correction');
-
-varid40 = netcdf.defVar(mainf,'REJ_mean_aspect_ratio_rectangle','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid40,'units','1');
-netcdf.putAtt(mainf, varid40,'long_name','Aspect Ratio of rejected particles by Rectangle fit');
-
-varid41 = netcdf.defVar(mainf,'REJ_mean_aspect_ratio_ellipse','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid41,'units','1');
-netcdf.putAtt(mainf, varid41,'long_name','Aspect Ratio of rejected particles by Ellipse fit');
-
-varid42 = netcdf.defVar(mainf,'REJ_mean_area_ratio','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid42,'units','1');
-netcdf.putAtt(mainf, varid42,'long_name','Area Ratio of rejected particles');
-
-varid43 = netcdf.defVar(mainf,'REJ_mean_perimeter','double',[dimid0 dimid2]); 
-netcdf.putAtt(mainf, varid43,'units','um');
-netcdf.putAtt(mainf, varid43,'long_name','mean perimeter of rejected particles');
-end
-
-if iSaveIntArrSV == 1
-varid44 = netcdf.defVar(mainf,'sum_IntArr','double',dimid2);
-netcdf.putAtt(mainf, varid44,'units','s');
-netcdf.putAtt(mainf, varid44,'long_name','sum of inter-arrival times, excluding the overload time for particles affected by saving of image data');
-
-varid45 = netcdf.defVar(mainf,'sample_vol','double',[dimid0 dimid2]);
-netcdf.putAtt(mainf, varid45,'units','cm^3');
-netcdf.putAtt(mainf, varid45,'long_name','sample volume for each bin');
-end
-
-netcdf.endDef(mainf)
-
-% Output Variables
-netcdf.putVar ( mainf, varid0, timehhmmss );
-netcdf.putVar ( mainf, varid1, cip2_binmin );
-netcdf.putVar ( mainf, varid2, cip2_binmax );
-netcdf.putVar ( mainf, varid3, cip2_binmid );
-netcdf.putVar ( mainf, varid4, cip2_bindD );
-
-% Good (accepted) particles
-netcdf.putVar ( mainf, varid5, cip2_conc_minR' );
-netcdf.putVar ( mainf, varid6, cip2_conc_areaDist);
-netcdf.putVar ( mainf, varid7, cip2_conc_AreaR' );
-netcdf.putVar ( mainf, varid8, cip2_n);
-netcdf.putVar ( mainf, varid9, cip2_area');
-netcdf.putVar ( mainf, varid10, cip2_iwc');
-netcdf.putVar ( mainf, varid11, permute(double(cip2_habitsd)./svol2a, [3 2 1]) );
-netcdf.putVar ( mainf, varid12, cip2_re );
-netcdf.putVar ( mainf, varid13, one_sec_ar );
-netcdf.putVar ( mainf, varid14, cip2_iwcbl' );
-netcdf.putVar ( mainf, varid15, 1-good_partpercent );
-netcdf.putVar ( mainf, varid16, cip2_vt' );
-netcdf.putVar ( mainf, varid17, cip2_pr' );
-netcdf.putVar ( mainf, varid18, permute(double(cip2_habitmsd)./svol2a, [3 2 1]) );
-netcdf.putVar ( mainf, varid19, cip2_partarea');
-netcdf.putVar ( mainf, varid20, cip2_countP_no');
-if iCreateAspectRatio == 1
-netcdf.putVar ( mainf, varid21, particle_aspectRatio);
-netcdf.putVar ( mainf, varid22, particle_aspectRatio1);
-end
-netcdf.putVar ( mainf, varid23, particle_areaRatio1);
-netcdf.putVar ( mainf, varid24, cip2_meanp');
-
-if iCreateBad == 1
-
-% Bad (rejected) particles
-netcdf.putVar ( mainf, varid25, bad_cip2_conc_minR' );
-netcdf.putVar ( mainf, varid26, bad_cip2_conc_areaDist);
-netcdf.putVar ( mainf, varid27, bad_cip2_conc_AreaR' );
-netcdf.putVar ( mainf, varid28, bad_cip2_n);
-netcdf.putVar ( mainf, varid29, bad_cip2_area');
-netcdf.putVar ( mainf, varid30, bad_cip2_iwc');
-netcdf.putVar ( mainf, varid31, permute(double(bad_cip2_habitsd)./svol2a, [3 2 1]) );
-netcdf.putVar ( mainf, varid32, bad_cip2_re );
-netcdf.putVar ( mainf, varid33, bad_one_sec_ar );
-netcdf.putVar ( mainf, varid34, bad_cip2_iwcbl' );
-netcdf.putVar ( mainf, varid35, bad_cip2_vt' );
-netcdf.putVar ( mainf, varid36, bad_cip2_pr' );
-netcdf.putVar ( mainf, varid37, permute(double(bad_cip2_habitmsd)./svol2a, [3 2 1]) );
-netcdf.putVar ( mainf, varid38, bad_cip2_partarea');
-netcdf.putVar ( mainf, varid39, bad_cip2_countP_no');
-netcdf.putVar ( mainf, varid40, bad_particle_aspectRatio);
-netcdf.putVar ( mainf, varid41, bad_particle_aspectRatio1);
-netcdf.putVar ( mainf, varid42, bad_particle_areaRatio1);
-netcdf.putVar ( mainf, varid43, bad_cip2_meanp');
-end
-
-if iSaveIntArrSV == 1
-    
-% Inter-arrival time and sample volume information
-netcdf.putVar ( mainf, varid44, time_interval200');
-netcdf.putVar ( mainf, varid45, svol2);
-end
-
-netcdf.close(mainf) % Close output NETCDF file 
-
-fprintf('sizeDist_Paris.m script completed %s\n',datestr(now));
-
+	sa2 = calc_sa_randombins(cip2_binmid,res,armdst,num_diodes,SAmethod, probetype); %(bins_mid,res,armdst,num_diodes)
+	
+	% Clocking problem correction
+	vol_scale_factor = tas/tasMax;
+	vol_scale_factor(vol_scale_factor < 1) = 1;
+	
+	TotalPC2_pre = TotalPC2;
+	
+	if probetype==2
+		time_interval200=1-time_interval72';
+		
+	elseif probetype==1
+		% Correct offset in probe particle count (TotalPC2) when we have negative values
+		TotalPC2(TotalPC2<0)=TotalPC2(TotalPC2<0)+2^16;
+		
+		% Derive a linear scale factor based on the difference between number of images (TotalPC1)
+		% and number of particles counted by the probe (TotalPC2).
+		time_interval199=(TotalPC1./TotalPC2)';
+		
+	elseif 0==probetype
+		time_interval200=1-time_interval72';
+	end
+	
+	% Experimental - Use with care!
+	% It was discovered that for data collected during the PECAN project, there were quite
+	% a few periods of time when the number of images we had for a 1-sec period of time was
+	% up to twice that of the number of particles the probe counted.
+	% This next if-statement contains code to find and change these instances to 1, resolving
+	% the far exaggerated concentrations that resulted otherwise.
+	if probetype==1
+		TotalPCerrIx = find(time_interval199 > 1);
+		time_interval200 = time_interval199;
+		time_interval200(TotalPCerrIx) = 1;
+		
+		fprintf(['Total image count exceeded probe particle count %d times\ntime_interval200',...
+            ' was set to 1 in these cases. See TotalPCerrIx variable for indices of occurence.\n\n'],...
+            length(TotalPCerrIx));
+	end
+	
+	
+	
+	
+	for j=1:num_bins
+		% Sample volume is in m-3
+		%     svol_old(j,:)=dof/100.*sa/100.*tas;
+		svol2(j,:) = sa2(j)*(1e-3)^2*time_interval200.*tas; %m3 .*vol_scale_factor
+	end
+	
+	svol2 = svol2*100^3; %cm3
+	
+	for j = 1:10
+		svol2a(:,:,j) = svol2';
+	end
+	
+	% Good (accepted) particles
+	cip2_conc_minR  = particle_dist_minR./svol2';
+	cip2_conc_AreaR = particle_dist_AreaR./svol2';
+	cip2_area = particle_area./svol2';
+	cip2_partarea = cip2_partarea./svol2';
+	cip2_iwc = cip2_iwc./svol2';
+	cip2_lwc = cip2_lwc./svol2';
+	cip2_iwcbl = cip2_iwcbl./svol2';
+	cip2_vt_ice = cip2_vt_ice./svol2';
+	cip2_vt_lw = cip2_vt_lw./svol2';
+	cip2_pr_ice = cip2_pr_ice./svol2';
+	cip2_pr_lw = cip2_pr_lw./svol2';
+	
+	cip2_countP_no  = particle_dist_minR.*repmat(binwidth,[length(tas) 1])/10; % un-normalized by binwitdh - Joe Finlon - 03/03/17
+    cip2_conc_areaDist = permute(double(area_dist2)./svol2a, [3 2 1]);
+    cip2_n = nansum(cip2_conc_minR.*repmat(binwidth,[length(tas) 1]),2)/10; % un-normalized by binwitdh & converted to cm^-3 - Joe Finlon - 03/03/17
+	
+	% Bad (rejected) particles
+	if iCreateBad
+		bad_cip2_conc_minR  = bad_particle_dist_minR./svol2';
+		bad_cip2_conc_AreaR = bad_particle_dist_AreaR./svol2';
+		bad_cip2_area = bad_particle_area./svol2';
+		bad_cip2_partarea = bad_cip2_partarea./svol2';
+		bad_cip2_iwc = bad_cip2_iwc./svol2';
+		bad_cip2_iwcbl = bad_cip2_iwcbl./svol2';
+		bad_cip2_vt = bad_cip2_vt./svol2';
+		bad_cip2_pr = bad_cip2_pr./svol2';
+		
+		bad_cip2_countP_no  = bad_particle_dist_minR.*repmat(binwidth,[length(tas) 1])/10; % un-normalized by binwitdh - Joe Finlon - 1/25/17
+		bad_cip2_conc_areaDist = permute(double(bad_area_dist2)./svol2a, [3 2 1]);
+		bad_cip2_n = nansum(bad_cip2_conc_minR.*repmat(binwidth,[length(tas) 1]),2)/10; % un-normalized by binwitdh & converted to cm^-3 - Joe Finlon - 1/25/17
+	end
+	
+	
+	
+	%% Output results into NETCDF files (mainf)
+	
+	fprintf('Now writing output files %s\n\n',datestr(now));
+	
+	if applyIntArrThresh
+		if iCreateBad
+			save([outfile(1:end-3) 'noShatters_wRejSD.mat']);
+		else
+			save([outfile(1:end-3) 'noShatters.mat']);
+		end
+	else
+		if iCreateBad
+			save([outfile(1:end-3) 'withShatters_wRejSD.mat']);
+		else
+			save([outfile(1:end-3) 'withShatters.mat']);
+		end
+		
+	end
+	
+	
+	% Define Dimensions
+	dimid0 = netcdf.defDim(mainf,'CIPcorrlen',num_bins);
+	dimid1 = netcdf.defDim(mainf,'CIParealen',10);
+	dimid2 = netcdf.defDim(mainf,'Time',length(timehhmmss));
+	dimid3 = netcdf.defDim(mainf,'Habit',10);
+	
+	% Define Global Attributes
+    NC_GLOBAL = netcdf.getConstant('NC_GLOBAL');
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Software', 'UIOPS/sizeDist');
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Institution', 'Univ. Illinois, Dept. Atmos. Sciences');
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Creation Time', datestr(now, 'yyyy/mm/dd HH:MM:SS'));
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Description', ['Contains size distributions of ',...
+        'particle count, mass, etc. & various bulk properties.']);
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Project', projectname);
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Data Source', infile);
+    netcdf.putAtt(mainf, NC_GLOBAL, 'Probe Type', probename);
+    if SAmethod==0
+        netcdf.putAtt(mainf, NC_GLOBAL, 'SA Method', 'Center-in');
+    elseif SAmethod==1
+        netcdf.putAtt(mainf, NC_GLOBAL, 'SA Method', 'Entire-in');
+    elseif SAmethod==2
+        netcdf.putAtt(mainf, NC_GLOBAL, 'SA Method', 'Using Heymsfield & Parrish (1978) correction');
+    end
+    if d_choice==1
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'L_x');
+    elseif d_choice==2
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'L_y');
+    elseif d_choice==3
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'mean(L_x,L_y)');
+    elseif d_choice==4
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'hypotenuse(L_x,L_y)');
+    elseif d_choice==5
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'max(L_x,L_y)');
+    elseif d_choice==6
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Dmax Definition', 'D of minimum enclosing circle');
+    end
+    if applyIntArrThresh && reaccptShatrs
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Shattering Algorithm',...
+            'Applied w/ reacceptance of particles');
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Reacceptance Criteria',...
+            ['D > ', num2str(reaccptD*1000), ' um; inter-arrival < ',...
+            num2str(reaccptMaxIA), ' sec'])
+    elseif applyIntArrThresh && ~reaccptShatrs
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Shattering Algorithm',...
+            'Applied without reacceptance of particles');
+    else
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Shattering Algorithm', 'Not applied');
+    end
+    if iCreateBad && iCreateAspectRatio && iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'SDs from rejected particles, SDs w/ aspect ratio, Sample volume info');
+    elseif iCreateBad && ~iCreateAspectRatio && iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'SDs from rejected particles, Sample volume info');
+    elseif iCreateBad && iCreateAspectRatio && ~iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'SDs from rejected particles, SDs w/ aspect ratio');
+    elseif iCreateBad && ~iCreateAspectRatio && ~iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'SDs from rejected particles');
+    elseif ~iCreateBad && iCreateAspectRatio && iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'SDs w/ aspect ratio, Sample volume info');
+    elseif ~iCreateBad && ~iCreateAspectRatio && iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'Sample volume info');
+    elseif ~iCreateBad && iCreateAspectRatio && ~iSaveIntArrSV
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved',...
+            'SDs w/ aspect ratio');
+    else
+        netcdf.putAtt(mainf, NC_GLOBAL, 'Optional Parameters Saved', 'None');
+    end
+	
+	% Define Variables
+	varid0 = netcdf.defVar(mainf,'time','double',dimid2);
+	netcdf.putAtt(mainf, varid0,'units','HHMMSS');
+	netcdf.putAtt(mainf, varid0,'name','Time');
+	
+	varid1 = netcdf.defVar(mainf,'bin_min','double',dimid0);
+	netcdf.putAtt(mainf, varid1,'units','millimeter');
+	netcdf.putAtt(mainf, varid1,'long_name','bin minimum size');
+	netcdf.putAtt(mainf, varid1,'short_name','bin min');
+	
+	varid2 = netcdf.defVar(mainf,'bin_max','double',dimid0);
+	netcdf.putAtt(mainf, varid2,'units','millimeter');
+	netcdf.putAtt(mainf, varid2,'long_name','bin maximum size');
+	netcdf.putAtt(mainf, varid2,'short_name','bin max');
+	
+	varid3 = netcdf.defVar(mainf,'bin_mid','double',dimid0);
+	netcdf.putAtt(mainf, varid3,'units','millimeter');
+	netcdf.putAtt(mainf, varid3,'long_name','bin midpoint size');
+	netcdf.putAtt(mainf, varid3,'short_name','bin mid');
+	
+	varid4 = netcdf.defVar(mainf,'bin_dD','double',dimid0);
+	netcdf.putAtt(mainf, varid4,'units','millimeter');
+	netcdf.putAtt(mainf, varid4,'long_name','bin size');
+	netcdf.putAtt(mainf, varid4,'short_name','bin size');
+	
+	% Good (accepted) particles
+	varid5 = netcdf.defVar(mainf,'conc_minR','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid5,'units','cm-4');
+	netcdf.putAtt(mainf, varid5,'long_name','Size distribution using Dmax');
+	netcdf.putAtt(mainf, varid5,'short_name','N(Dmax)');
+	
+	varid6 = netcdf.defVar(mainf,'area','double',[dimid1 dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid6,'units','cm-4');
+	netcdf.putAtt(mainf, varid6,'long_name','binned area ratio');
+	netcdf.putAtt(mainf, varid6,'short_name','binned area ratio');
+	
+	varid7 = netcdf.defVar(mainf,'conc_AreaR','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid7,'units','cm-4');
+	netcdf.putAtt(mainf, varid7,'long_name','Size distribution using area-equivalent Diameter');
+	netcdf.putAtt(mainf, varid7,'short_name','N(Darea)');
+	
+	varid8 = netcdf.defVar(mainf,'n','double',dimid2);
+	netcdf.putAtt(mainf, varid8,'units','cm-3');
+	netcdf.putAtt(mainf, varid8,'long_name','number concentration');
+	netcdf.putAtt(mainf, varid8,'short_name','N');
+	
+	varid9 = netcdf.defVar(mainf,'total_area','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid9,'units','mm2/cm4');
+	netcdf.putAtt(mainf, varid9,'long_name','projected area (extinction)');
+	netcdf.putAtt(mainf, varid9,'short_name','Ac');
+	
+	varid10 = netcdf.defVar(mainf,'mass_ice','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid10,'units','g/cm4');
+	netcdf.putAtt(mainf, varid10,'long_name','mass of ice using m-D relations');
+	netcdf.putAtt(mainf, varid10,'short_name','mass_ice');
+	
+	varid11 = netcdf.defVar(mainf,'mass_lw','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid11,'units','g/cm4');
+	netcdf.putAtt(mainf, varid11,'long_name','mass of liquid water using (pi/6)*(D^3)*rho_w');
+	netcdf.putAtt(mainf, varid11,'short_name','mass_lw');
+	
+	varid12 = netcdf.defVar(mainf,'habitsd','double',[dimid3 dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid12,'units','cm-4');
+	netcdf.putAtt(mainf, varid12,'long_name','Size Distribution with Habit');
+	netcdf.putAtt(mainf, varid12,'short_name','habit SD');
+	
+	varid13 = netcdf.defVar(mainf,'re','double',dimid2);
+	netcdf.putAtt(mainf, varid13,'units','mm');
+	netcdf.putAtt(mainf, varid13,'long_name','effective radius');
+	netcdf.putAtt(mainf, varid13,'short_name','Re');
+	
+	varid14 = netcdf.defVar(mainf,'ar','double',dimid2);
+	netcdf.putAtt(mainf, varid14,'units','100/100');
+	netcdf.putAtt(mainf, varid14,'long_name','Area Ratio');
+	netcdf.putAtt(mainf, varid14,'short_name','AR');
+	
+	varid15 = netcdf.defVar(mainf,'massBL','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid15,'units','g/cm4');
+	netcdf.putAtt(mainf, varid15,'long_name','mass using Baker and Lawson method');
+	netcdf.putAtt(mainf, varid15,'short_name','mass_BL');
+	
+	varid16 = netcdf.defVar(mainf,'Reject_ratio','double',dimid2);
+	netcdf.putAtt(mainf, varid16,'units','100/100');
+	netcdf.putAtt(mainf, varid16,'long_name','Reject Ratio');
+	
+	varid17 = netcdf.defVar(mainf,'vt_ice','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid17,'units','g/cm4');
+	netcdf.putAtt(mainf, varid17,'long_name','Mass-weighted terminal velocity for ice');
+	
+	varid18 = netcdf.defVar(mainf,'vt_lw','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid18,'units','g/cm4');
+	netcdf.putAtt(mainf, varid18,'long_name','Mass-weighted terminal velocity for liquid water');
+	
+	varid19 = netcdf.defVar(mainf,'Prec_rate_ice','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid19,'units','mm/hr');
+	netcdf.putAtt(mainf, varid19,'long_name','Precipitation Rate for Ice');
+	
+	varid20 = netcdf.defVar(mainf,'Prec_rate_lw','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid20,'units','mm/hr');
+	netcdf.putAtt(mainf, varid20,'long_name','Precipitation Rate for Liquid Water');
+	
+	varid21 = netcdf.defVar(mainf,'habitmsd','double',[dimid3 dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid21,'units','g/cm-4');
+	netcdf.putAtt(mainf, varid21,'long_name','Mass Size Distribution with Habit');
+	netcdf.putAtt(mainf, varid21,'short_name','Habit Mass SD');
+	
+	varid22 = netcdf.defVar(mainf,'Calcd_area','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid22,'units','mm^2/cm4');
+	netcdf.putAtt(mainf, varid22,'long_name','Particle Area Calculated using A-D realtions');
+	netcdf.putAtt(mainf, varid22,'short_name','Ac_calc');
+	
+	varid23 = netcdf.defVar(mainf,'count','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid23,'units','1');
+	netcdf.putAtt(mainf, varid23,'long_name','number count for partial images without any correction');
+	
+	if iCreateAspectRatio
+		varid24 = netcdf.defVar(mainf,'mean_aspect_ratio_rectangle','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid24,'units','1');
+		netcdf.putAtt(mainf, varid24,'long_name','Aspect Ratio by Rectangle fit');
+		
+		varid25 = netcdf.defVar(mainf,'mean_aspect_ratio_ellipse','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid25,'units','1');
+		netcdf.putAtt(mainf, varid25,'long_name','Aspect Ratio by Ellipse fit');
+	end
+	
+	varid26 = netcdf.defVar(mainf,'mean_area_ratio','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid26,'units','1');
+	netcdf.putAtt(mainf, varid26,'long_name','Area Ratio');
+	
+	varid27 = netcdf.defVar(mainf,'mean_perimeter','double',[dimid0 dimid2]);
+	netcdf.putAtt(mainf, varid27,'units','um');
+	netcdf.putAtt(mainf, varid27,'long_name','mean perimeter');
+	
+	if iSaveIntArrSV == 1
+		varid28 = netcdf.defVar(mainf,'sample_vol','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid28,'units','cm^3');
+		netcdf.putAtt(mainf, varid28,'long_name','sample volume for each bin');
+		
+		varid44 = netcdf.defVar(mainf,'sum_IntArr','double',dimid2);
+		netcdf.putAtt(mainf, varid44,'units','s');
+		netcdf.putAtt(mainf, varid44,'long_name','sum of inter-arrival times, excluding the overload time for particles affected by saving of image data');
+	end
+	
+	% Bad (rejected) particles
+	if iCreateBad
+		varid101 = netcdf.defVar(mainf,'REJ_conc_minR','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid101,'units','cm-4');
+		netcdf.putAtt(mainf, varid101,'long_name','Size distribution of rejected particles using Dmax');
+		netcdf.putAtt(mainf, varid101,'short_name','N(Dmax) rejected');
+		
+		varid102 = netcdf.defVar(mainf,'REJ_area','double',[dimid1 dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid102,'units','cm-4');
+		netcdf.putAtt(mainf, varid102,'long_name','binned area ratio of rejected particles');
+		netcdf.putAtt(mainf, varid102,'short_name','binned area ratio of rejected particles');
+		
+		varid103 = netcdf.defVar(mainf,'REJ_conc_AreaR','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid103,'units','cm-4');
+		netcdf.putAtt(mainf, varid103,'long_name','Size distribution of rejected particles using area-equivalent Diameter');
+		netcdf.putAtt(mainf, varid103,'short_name','N(Darea) rejected');
+		
+		varid104 = netcdf.defVar(mainf,'REJ_n','double',dimid2);
+		netcdf.putAtt(mainf, varid104,'units','cm-3');
+		netcdf.putAtt(mainf, varid104,'long_name','number concentration of rejected particles');
+		netcdf.putAtt(mainf, varid104,'short_name','N_rejected');
+		
+		varid105 = netcdf.defVar(mainf,'REJ_total_area','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid105,'units','mm2/cm4');
+		netcdf.putAtt(mainf, varid105,'long_name','projected area (extinction) of rejected particles');
+		netcdf.putAtt(mainf, varid105,'short_name','Ac_rejected');
+		
+		varid106 = netcdf.defVar(mainf,'REJ_mass','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid106,'units','g/cm4');
+		netcdf.putAtt(mainf, varid106,'long_name','mass of rejected particles using m-D relations');
+		netcdf.putAtt(mainf, varid106,'short_name','mass_rejected');
+		
+		varid107 = netcdf.defVar(mainf,'REJ_habitsd','double',[dimid3 dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid107,'units','cm-4');
+		netcdf.putAtt(mainf, varid107,'long_name','Size Distribution with Habit of rejected particles');
+		netcdf.putAtt(mainf, varid107,'short_name','habit SD rejected');
+		
+		varid108 = netcdf.defVar(mainf,'REJ_re','double',dimid2);
+		netcdf.putAtt(mainf, varid108,'units','mm');
+		netcdf.putAtt(mainf, varid108,'long_name','effective radius of rejected particles');
+		netcdf.putAtt(mainf, varid108,'short_name','Re_rejected');
+		
+		varid109 = netcdf.defVar(mainf,'REJ_ar','double',dimid2);
+		netcdf.putAtt(mainf, varid109,'units','100/100');
+		netcdf.putAtt(mainf, varid109,'long_name','Area Ratio of rejected particles');
+		netcdf.putAtt(mainf, varid109,'short_name','AR_rejected');
+		
+		varid110 = netcdf.defVar(mainf,'REJ_massBL','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid110,'units','g/cm4');
+		netcdf.putAtt(mainf, varid110,'long_name','mass of rejected particles using Baker and Lawson method');
+		netcdf.putAtt(mainf, varid110,'short_name','mass_BL_rejected');
+		
+		varid111 = netcdf.defVar(mainf,'REJ_vt','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid111,'units','g/cm4');
+		netcdf.putAtt(mainf, varid111,'long_name','Mass-weighted terminal velocity of rejected particles');
+		
+		varid112 = netcdf.defVar(mainf,'REJ_Prec_rate','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid112,'units','mm/hr');
+		netcdf.putAtt(mainf, varid112,'long_name','Precipitation Rate of rejected particles');
+		
+		varid113 = netcdf.defVar(mainf,'REJ_habitmsd','double',[dimid3 dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid113,'units','g/cm-4');
+		netcdf.putAtt(mainf, varid113,'long_name','Mass Size Distribution with Habit of rejected particles');
+		netcdf.putAtt(mainf, varid113,'short_name','Habit Mass SD rejected');
+		
+		varid114 = netcdf.defVar(mainf,'REJ_Calcd_area','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid114,'units','mm^2/cm4');
+		netcdf.putAtt(mainf, varid114,'long_name','Particle Area of rejected particles Calculated using A-D realtions');
+		netcdf.putAtt(mainf, varid114,'short_name','Ac_calc_rejected');
+		
+		varid115 = netcdf.defVar(mainf,'REJ_count','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid115,'units','1');
+		netcdf.putAtt(mainf, varid115,'long_name','number count of rejected particles for partial images without any correction');
+		
+		if iCreateAspectRatio
+			varid116 = netcdf.defVar(mainf,'REJ_mean_aspect_ratio_rectangle','double',[dimid0 dimid2]);
+			netcdf.putAtt(mainf, varid116,'units','1');
+			netcdf.putAtt(mainf, varid116,'long_name','Aspect Ratio of rejected particles by Rectangle fit');
+			
+			varid117 = netcdf.defVar(mainf,'REJ_mean_aspect_ratio_ellipse','double',[dimid0 dimid2]);
+			netcdf.putAtt(mainf, varid117,'units','1');
+			netcdf.putAtt(mainf, varid117,'long_name','Aspect Ratio of rejected particles by Ellipse fit');
+		end
+		
+		varid118 = netcdf.defVar(mainf,'REJ_mean_area_ratio','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid118,'units','1');
+		netcdf.putAtt(mainf, varid118,'long_name','Area Ratio of rejected particles');
+		
+		varid119 = netcdf.defVar(mainf,'REJ_mean_perimeter','double',[dimid0 dimid2]);
+		netcdf.putAtt(mainf, varid119,'units','um');
+		netcdf.putAtt(mainf, varid119,'long_name','mean perimeter of rejected particles');
+	end
+	
+	
+	netcdf.endDef(mainf)
+	
+	% Output Variables
+	netcdf.putVar ( mainf, varid0, timehhmmss );
+	netcdf.putVar ( mainf, varid1, cip2_binmin );
+	netcdf.putVar ( mainf, varid2, cip2_binmax );
+	netcdf.putVar ( mainf, varid3, cip2_binmid );
+	netcdf.putVar ( mainf, varid4, cip2_bindD );
+	
+	% Good (accepted) particles
+	netcdf.putVar ( mainf, varid5, cip2_conc_minR' );
+	netcdf.putVar ( mainf, varid6, cip2_conc_areaDist);
+	netcdf.putVar ( mainf, varid7, cip2_conc_AreaR' );
+	netcdf.putVar ( mainf, varid8, cip2_n);
+	netcdf.putVar ( mainf, varid9, cip2_area');
+	netcdf.putVar ( mainf, varid10, cip2_iwc');
+	netcdf.putVar ( mainf, varid11, cip2_lwc');
+	netcdf.putVar ( mainf, varid12, permute(double(cip2_habitsd)./svol2a, [3 2 1]) );
+	netcdf.putVar ( mainf, varid13, cip2_re );
+	netcdf.putVar ( mainf, varid14, one_sec_ar );
+	netcdf.putVar ( mainf, varid15, cip2_iwcbl' );
+	netcdf.putVar ( mainf, varid16, 1-good_partpercent );
+	netcdf.putVar ( mainf, varid17, cip2_vt_ice' );
+	netcdf.putVar ( mainf, varid18, cip2_vt_lw' );
+	netcdf.putVar ( mainf, varid19, cip2_pr_ice' );
+	netcdf.putVar ( mainf, varid20, cip2_pr_lw' );
+	netcdf.putVar ( mainf, varid21, permute(double(cip2_habitmsd)./svol2a, [3 2 1]) );
+	netcdf.putVar ( mainf, varid22, cip2_partarea');
+	netcdf.putVar ( mainf, varid23, cip2_countP_no');
+	if iCreateAspectRatio
+		netcdf.putVar ( mainf, varid24, particle_aspectRatio);
+		netcdf.putVar ( mainf, varid25, particle_aspectRatio1);
+	end
+	netcdf.putVar ( mainf, varid26, particle_areaRatio1);
+	netcdf.putVar ( mainf, varid27, cip2_meanp');
+	
+	if iSaveIntArrSV == 1
+		% Inter-arrival time and sample volume information
+		netcdf.putVar ( mainf, varid28, svol2);
+		netcdf.putVar ( mainf, varid44, time_interval200');
+	end
+	
+	% Bad (rejected) particles
+	if iCreateBad
+		netcdf.putVar ( mainf, varid101, bad_cip2_conc_minR' );
+		netcdf.putVar ( mainf, varid102, bad_cip2_conc_areaDist);
+		netcdf.putVar ( mainf, varid103, bad_cip2_conc_AreaR' );
+		netcdf.putVar ( mainf, varid104, bad_cip2_n);
+		netcdf.putVar ( mainf, varid105, bad_cip2_area');
+		netcdf.putVar ( mainf, varid106, bad_cip2_iwc');
+		netcdf.putVar ( mainf, varid107, permute(double(bad_cip2_habitsd)./svol2a, [3 2 1]) );
+		netcdf.putVar ( mainf, varid108, bad_cip2_re );
+		netcdf.putVar ( mainf, varid109, bad_one_sec_ar );
+		netcdf.putVar ( mainf, varid110, bad_cip2_iwcbl' );
+		netcdf.putVar ( mainf, varid111, bad_cip2_vt' );
+		netcdf.putVar ( mainf, varid112, bad_cip2_pr' );
+		netcdf.putVar ( mainf, varid113, permute(double(bad_cip2_habitmsd)./svol2a, [3 2 1]) );
+		netcdf.putVar ( mainf, varid114, bad_cip2_partarea');
+		netcdf.putVar ( mainf, varid115, bad_cip2_countP_no');
+		if iCreateAspectRatio
+			netcdf.putVar ( mainf, varid116, bad_particle_aspectRatio);
+			netcdf.putVar ( mainf, varid117, bad_particle_aspectRatio1);
+		end
+		netcdf.putVar ( mainf, varid118, bad_particle_areaRatio1);
+		netcdf.putVar ( mainf, varid119, bad_cip2_meanp');
+	end
+	
+	
+	netcdf.close(mainf) % Close output NETCDF file
+	
+	netcdf.close(prmsF);
+	
+	fprintf('sizeDist_Paris.m script completed %s\n',datestr(now));
+	
 end


### PR DESCRIPTION
Modified imgProc/sizeDist to allow for a small number of PECAN/other case-specific processing.

Added a new version of the python automatic processing wrapper which now takes command line arguments to eliminate the need for unique python wrappers _and_ slurm batch scripts.

Added a few additional matlab wrapper script examples (specific to PECAN, but extensible to other projects). Similar in many ways to existing wrappers, so feel free to drop these from the merge if you'd like - just wanted to share if they'd be helpful.